### PR TITLE
Fixes for download and staging of data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .git
-.env
+*.env
 airflow_settings.yaml
 astro
 Dockerfile
+temp
+__pycache__

--- a/dags/govt_file_download.py
+++ b/dags/govt_file_download.py
@@ -13,11 +13,14 @@ Currently converts the following file formats. All others are loaded to s3 after
 import json
 from airflow import DAG
 from datetime import datetime, timedelta
+from airflow.decorators import task_group
 from airflow.operators.python import PythonOperator
-from include.retrieve_gov_file import retrieve_gov_file
+from include.retrieve_gov_file import retrieve_gov_file, clear_files_and_subdirs
 
 gov_files = "include/gov_files.json"
 BUCKET = "civic-data-warehouse-lz"
+prep_directory = "/tmp/prep/" 
+
 # Tasks currently fail if run on all gov_docs at once, but confirmed to work in smaller batches. Worker resource constraints?
 with DAG(
     "govt_file_download",
@@ -28,16 +31,32 @@ with DAG(
     doc_md=doc_md_DAG,
     default_args={"retries": 3, "retry_delay": timedelta(minutes=1)},
 ) as dag:
-    with open(gov_files, "r") as read_file:
-        gov_file_data = json.load(read_file)
-        for file in gov_file_data["gov_files"]:
-            upload_file = PythonOperator(
-                task_id="files_to_s3_" + file["file_name"],
-                python_callable=retrieve_gov_file,
-                op_kwargs={
-                    "filename": file["file_name"],
-                    "file_url": file["file_location"],
-                    "bucket": BUCKET,
-                    "s3_conn_id": "s3_datalake",
-                },
-            )
+    
+    @task_group()
+    def upload_all_files():
+        with open(gov_files, "r") as read_file:
+            gov_file_data = json.load(read_file)
+            for file in gov_file_data["gov_files"]:
+                task_id="files_to_s3_" + file["file_name"]
+                upload_file = PythonOperator(
+                    task_id=task_id,
+                    python_callable=retrieve_gov_file,
+                    op_kwargs={
+                        "filename": file["file_name"],
+                        "file_url": file["file_location"],
+                        "bucket": BUCKET,
+                        "s3_conn_id": "s3_datalake",
+                        "task_id": task_id,
+                        "base_prep_dir": prep_directory
+                    },
+                )
+    
+    cleanup_task = PythonOperator(
+        task_id='clear_tmp_directory',
+        python_callable=clear_files_and_subdirs,
+        op_kwargs={
+            "dir_to_clear": prep_directory
+        },
+    )
+
+    upload_all_files() >> cleanup_task

--- a/include/gov_files.json
+++ b/include/gov_files.json
@@ -9,12 +9,28 @@
         "file_location": "http://www.stlouis-mo.gov/data/upload/data-files/codes.zip"
     },
     {
-        "file_name": "building_permits_emp.zip",
-        "file_location": "http://www.stlouis-mo.gov/data/upload/data-files/prmemp.zip"
+        "file_name": "building_permits_last_30_days.csv",
+        "file_location": "https://www.stlouis-mo.gov/customcf/endpoints/building-permits/building-permits-30-days-export.cfm?permitType=all&dataType=csv"
     },
     {
-        "file_name": "building_permits_bdo.zip",
-        "file_location": "http://www.stlouis-mo.gov/data/upload/data-files/prmbdo.zip"
+        "file_name": "demolition_permits_last_30_days.csv",
+        "file_location": "https://www.stlouis-mo.gov/customcf/endpoints/demolition-permits/demolition-permits-30-days-export.cfm?permitType=all&dataType=csv"
+    },
+    {
+        "file_name": "electrical_permits_last_30_days.csv",
+        "file_location": "https://www.stlouis-mo.gov/customcf/endpoints/electrical-permits/electrical-permits-30-days-export.cfm?permitType=all&dataType=csv"
+    },
+    {
+        "file_name": "mechanical_permits_last_30_days.csv",
+        "file_location": "https://www.stlouis-mo.gov/customcf/endpoints/mechanical-permits/mechanical-permits-30-days-export.cfm?permitType=all&dataType=csv"
+    },
+    {
+        "file_name": "occupancy_permits_last_30_days.csv",
+        "file_location": "https://www.stlouis-mo.gov/customcf/endpoints/occupancy-permits/occupancy-permits-30-days-export.cfm?permitType=all&dataType=csv"
+    },
+    {
+        "file_name": "plumbing_permits_last_30_days.csv",
+        "file_location": "https://www.stlouis-mo.gov/customcf/endpoints/plumbing-permits/plumbing-permits-30-days-export.cfm?permitType=all&dataType=csv"
     },
     {
         "file_name": "historical_conservation.zip",

--- a/include/retrieve_gov_file.py
+++ b/include/retrieve_gov_file.py
@@ -1,15 +1,80 @@
-import shutil
-import wget
+import subprocess, os
+import shutil, wget
+import pandas
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from zipfile import ZipFile
-import subprocess, os
+from airflow.utils.log import logging_mixin
+
+def retrieve_gov_file(filename, file_url, bucket, s3_conn_id, task_id, base_prep_dir):
+    """
+    Downloads a single file to a temporary directory, recursively unzips it, converts .mdb files if needed, 
+     and uploads it to s3
+    :return: none
+    """
+    logger = logging_mixin.LoggingMixin().logger()
+
+    prep_dir = build_temp_subdirectory(task_id, base_prep_dir, logger)
+
+    download_dest = download_gov_file(filename, file_url, base_prep_dir, logger)
+
+    if filename.endswith(".zip"):
+        unpack_zip(download_dest, prep_dir, logger)
+    else:
+        logger.info(f"Moving {download_dest} into {prep_dir} directory")
+        shutil.move(download_dest, prep_dir)
+        
+    for file in os.listdir(prep_dir):
+        logger.info(f"{file} found in {prep_dir} for sending to S3")
+        if file.endswith(".mdb"):
+            export_mdb_file(bucket, s3_conn_id, logger, file, prep_dir)
+        elif file.endswith(".xls"):
+            export_xls_file(bucket, s3_conn_id, logger, file, prep_dir)
+        elif file.endswith(".txt"):
+            export_txt_file(bucket, s3_conn_id, logger, file, prep_dir)
+        elif file.endswith(".csv"):
+            upload_to_s3(bucket, s3_conn_id, logger, file, prep_dir)
+        else:
+            logger.warning(f"{file} is not an .mdb or .csv and is ignored")
 
 
-def unpack_zip(path_to_zip, extract_path):
+def build_temp_subdirectory(task_id, base_prep_dir, logger):
+    """
+    Generate a subdirectory to contain task-specific files. Ensure directory exists and is empty.
+    :return: temp directory to use
+    """
+
+    # Feel free to use any naming scheme you want here. Using the task_id was the simplest option,
+    #  but possibly not the best.
+    safe_dirname = "".join(char for char in task_id if char.isalnum())
+    prep_dir = os.path.join(base_prep_dir, safe_dirname[:99])
+    logger.info(f"using tmp directory '{prep_dir}'")
+        
+    if not os.path.exists(prep_dir):
+        logger.info(f"Creating directory {prep_dir}")
+        os.makedirs(prep_dir)
+
+    clear_files_and_subdirs(prep_dir)
+    
+    return prep_dir
+
+
+def download_gov_file(filename, file_url, base_prep_dir, logger):
+    """
+    Download the source file to the base prep directory.
+    :return: full path to downloaded file
+    """
+    download_dest = os.path.join(base_prep_dir, filename)
+    wget.download(file_url, download_dest)
+    logger.info(f"{download_dest} downloaded")
+    return download_dest
+
+
+def unpack_zip(path_to_zip, extract_path, logger):
     """
     Recursively unzips a file and outputs its content to a directory.
     :return: None
     """
+    logger.info(f"unzipping {path_to_zip} into {extract_path}")
     parent_archive = ZipFile(path_to_zip)
     parent_archive.extractall(extract_path)
     namelist = parent_archive.namelist()
@@ -17,94 +82,122 @@ def unpack_zip(path_to_zip, extract_path):
     for name in namelist:
         try:
             if name.endswith(".zip"):
-                unpack_zip(path_to_zip=extract_path + name, extract_path=extract_path)
-                os.remove(extract_path + name)
+                inner_zipfile = os.path.join(extract_path, name)
+                unpack_zip(path_to_zip=inner_zipfile, extract_path=extract_path, logger=logger)
+                os.remove(inner_zipfile)
+                logger.info(f"{name} successfully unzipped")
         except:
-            print(name + " is not a .zip")
-            print(extract_path + name)
+            logger.error(f"{name} is not a .zip - full path : {os.path.join(extract_path, name)}")
             pass
 
 
-def upload_to_s3(s3_conn_id, filename, key, bucket):
+def upload_to_s3(bucket, s3_conn_id, logger, file, prep_dir):
     """
     Uploads a target file to s3
     :return: None
     """
+    key = file.replace(" ", "")
+    source_file = os.path.join(prep_dir, file)
+    logger.info(f"Moving {source_file} into s3 bucket {bucket}")
     s3_hook = S3Hook(aws_conn_id=s3_conn_id)
-    s3_hook.load_file(filename=filename, key=key, bucket_name=bucket, replace=True)
+    s3_hook.load_file(filename=source_file, key=key, bucket_name=bucket, replace=True)
+    logger.info(f"{source_file} successfully uploaded to s3 in bucket {bucket} and with key {key}")
+    logger.info(f"{file} successfully loaded to S3")
 
 
-def retrieve_gov_file(filename, file_url, bucket, s3_conn_id):
+def export_txt_file(bucket, s3_conn_id, logger, file, prep_dir):
     """
-    Downloads a single file to a temporary directory, recursively unzips it, and uploads it to s3
-    :return: none
+    Test the file to see if it's a valid .csv. If so, rename it and upload it.
+    :return: None
     """
-    download_dest = "/tmp/" + filename
-    wget.download(file_url, download_dest)
-    print("clearing tmp directory")
-    for root, dirs, files in os.walk("/tmp/prepped"):
-        for file in files:
-            os.remove(os.path.join(root, file))
-    print("tmp directory cleared")
-    print(download_dest + " downloaded")
-    if filename.endswith(".zip"):
-        unpack_zip(download_dest, "/tmp/prepped/")
-    else:
-        shutil.move(
-            download_dest,
-            "/tmp/prepped/" + os.path.basename(download_dest).split("/")[-1],
-        )
-    for file in os.listdir("/tmp/prepped/"):
-        if file.endswith(".mdb"):
-            print(file + " identified as .mdb")
-            try:
-                table_names = subprocess.Popen(
-                    "mdb-tables /tmp/prepped/" + file,
+    logger.info(f"{file} identified as .txt")
+    prepped_file = os.path.join(prep_dir, file)
+    try:
+        pandas.read_csv(prepped_file, dtype=str)
+    except Exception:
+        logger.exception(f"file {prepped_file} does not appear to be a csv")
+        raise
+    csv_filename = os.path.splitext(file)[0] + ".csv"
+    full_csv_filename = os.path.join(prep_dir, csv_filename)
+    shutil.move(prepped_file, full_csv_filename)
+    logger.info(f"renamed {prepped_file} to {full_csv_filename}")
+    upload_to_s3(bucket, s3_conn_id, logger, csv_filename, prep_dir)
+
+
+def export_xls_file(bucket, s3_conn_id, logger, file, prep_dir):
+    """
+    Convert the .xls file to a .csv and upload it.
+    :return: None
+    """
+    logger.info(f"{file} identified as .xls")
+    prepped_file = os.path.join(prep_dir, file)
+    excel_dataframe = pandas.read_excel(prepped_file, engine="xlrd", dtype=str)
+    csv_filename = os.path.splitext(file)[0] + ".csv"
+    full_csv_filename = os.path.join(prep_dir, csv_filename)
+    excel_dataframe.to_csv(full_csv_filename)
+    logger.info(f"loaded {prepped_file} and written all data to {full_csv_filename}")
+    upload_to_s3(bucket, s3_conn_id, logger, csv_filename, prep_dir)
+
+def export_mdb_file(bucket, s3_conn_id, logger, file, prep_dir):
+    """
+    Strip all tables in an .mdb file into separate .csv files. Upload the resulting .csv files to S3.
+    :return: None
+    """
+    logger.info(f"{file} identified as .mdb")
+    try:
+        prepped_file = os.path.join(prep_dir, file)
+        cmd_open_mdb = f"mdb-tables {prepped_file}"
+        logger.info(f"executing command {cmd_open_mdb}")
+        table_names = subprocess.Popen(
+                    cmd_open_mdb,
                     stdout=subprocess.PIPE,
                     shell=True,
                 )
-                output = table_names.communicate()[0].decode("ascii")
-                print(output)
-                tables = output.split(" ")
-                print(tables)
-            except subprocess.CalledProcessError as e:
-                raise RuntimeError(
+        output = table_names.communicate()[0].decode("ascii")
+        logger.debug(output)
+        tables = output.split(" ")
+        logger.debug(tables)
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(
                     "command '{}' return with error (code {}): {}".format(
                         e.cmd, e.returncode, e.output
                     )
                 )
-            for table in tables:
-                if table != "" and table != "\n":
-                    export_file = (
-                        "/tmp/prepped/"
-                        + os.path.splitext(file)[0]
-                        + "_"
-                        + table.replace(" ", "_")
-                        + ".csv"
-                    )
-                    print("Exporting " + table)
-                    with open(export_file, "wb") as f:
-                        try:
-                            subprocess.check_call(
-                                ["mdb-export", "/tmp/prepped/" + file, table], stdout=f
+    for table in tables:
+        if table != "" and table != "\n":
+            export_file = os.path.splitext(file)[0] + "_" + table.replace(" ", "_") + ".csv"
+            export_fullpath = os.path.join(prep_dir, export_file)
+            logger.info(f"Exporting {table} to {export_fullpath}")
+            with open(export_fullpath, "wb") as f:
+                try:
+                    subprocess.check_call(
+                                ["mdb-export", prepped_file, table], stdout=f
                             )
-                        except subprocess.CalledProcessError as e:
-                            raise RuntimeError(
+                except subprocess.CalledProcessError as e:
+                    raise RuntimeError(
                                 "command '{}' return with error (code {}): {}".format(
                                     e.cmd, e.returncode, e.output
                                 )
                             )
+                
+            upload_to_s3(bucket, s3_conn_id, logger, export_file, prep_dir)
 
-    for file in os.listdir("/tmp/prepped/"):
-        print(file + " found in /tmp/prepped/ for sending to S3")
-        if file.endswith(".csv"):
-            OBJECT = file.replace(" ", "")
-            PATH_TO_FILE = "/tmp/prepped/" + file
-            BUCKET = bucket
-            upload_to_s3(
-                s3_conn_id=s3_conn_id,
-                filename=PATH_TO_FILE,
-                bucket=BUCKET,
-                key=OBJECT,
-            )
-            print(file + " successfully loaded to S3")
+
+def clear_files_and_subdirs(dir_to_clear):
+    """
+    Remove all files and subdirectories in a directory.
+    :return: None
+    """
+    logger = logging_mixin.LoggingMixin().logger()
+    logger.info(f"clearing all files in {dir_to_clear}")
+    for root, dirs, files in os.walk(dir_to_clear):
+        for file in files:
+            file_to_remove = os.path.join(root, file)
+            logger.debug(f"removing file {file_to_remove}")
+            os.remove(file_to_remove)
+    for root, dirs, files in os.walk(dir_to_clear):
+        for dir in dirs:
+            subdir_to_remove = os.path.join(root, dir)
+            logger.debug(f"removing subdirectory {subdir_to_remove}")
+            os.rmdir(subdir_to_remove)
+    logger.info("tmp directory cleared")

--- a/include/staging_table_prep.py
+++ b/include/staging_table_prep.py
@@ -1,26 +1,29 @@
 import os
+import logging
+from logging import Logger
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.postgres.hooks.postgres import PostgresHook
+from airflow.utils.log import logging_mixin
 import pandas as pd
 import numpy as np
 from io import StringIO
 import re
 
 
-def download_from_s3(key: str, bucket_name: str, s3_conn_id: str) -> str:
+def download_from_s3(key: str, bucket_name: str, s3_conn_id: str):
+    logger = logging_mixin.LoggingMixin().logger()
     download_dest = "/tmp/"
-    print(download_dest)
     hook = S3Hook(aws_conn_id=s3_conn_id)
     filename = hook.download_file(
         key=key, bucket_name=bucket_name, local_path=download_dest
     )
-    print(filename + " downloaded")
+    logger.info(filename + " downloaded")
     os.rename(src=filename, dst=download_dest + key)
-    print(filename + " renamed to " + download_dest + key)
+    logger.info(filename + " renamed to " + download_dest + key)
 
 
-def execute_query(query, conn_id):
-    hook = PostgresHook(postgres_conn_id=conn_id)
+def execute_query(query, conn_id, logger:Logger):
+    hook = PostgresHook(postgres_conn_id=conn_id, log_sql=(logger.level==logging.DEBUG))
     hook.run(sql=query)
 
 
@@ -138,16 +141,14 @@ def clean_column_name(column_name):
 
 
 def create_table_in_postgres(filename, postgres_conn):
+    logger = logging_mixin.LoggingMixin().logger()
     tablename = filename.replace("/tmp/", "").replace(".csv", "").replace("-", "_")
-    with open(filename, "r") as fileInput:
-        # Extract first line of file
-        firstLine = fileInput.readline().strip()
+    df = pd.read_csv(filename, dtype=str)
 
-    # Split columns into an array
-    columns = firstLine.split(",")
-    print("List of columns:")
-    for column in columns:
-        print(column)
+    columns = [clean_column_name(col) for col in df.columns]
+    logger.info("List of columns:")
+    for col_index, column in enumerate(columns):
+        logger.info(f"column index {col_index} is '{column}'")
 
     # Build SQL code to drop table if exists and create table
     sqlQueryCreate = ""
@@ -160,22 +161,24 @@ def create_table_in_postgres(filename, postgres_conn):
 
     sqlQueryCreate = sqlQueryCreate[:-2]
     sqlQueryCreate += ");"
-    print(sqlQueryCreate)
+    logger.debug(sqlQueryCreate)
 
     # Run sqlQueryCreate in Postgres
-    execute_query(sqlQueryCreate, postgres_conn)
+    execute_query(sqlQueryCreate, postgres_conn, logger)
 
 
 def create_staging_table(bucket, s3_conn_id, postgres_conn_id, key):
+    logger = logging_mixin.LoggingMixin().logger()
     download_from_s3(key=key, bucket_name=bucket, s3_conn_id=s3_conn_id)
-    print("Downloaded " + key)
-    print("Attempting to create table for " + key)
+    logger.info("Downloaded " + key)
+    logger.info("Attempting to create table for " + key)
     create_table_in_postgres(filename="/tmp/" + key, postgres_conn=postgres_conn_id)
 
 
 def SQL_INSERT_STATEMENT_FROM_DATAFRAME(SOURCE, TARGET):
     # Generate the SQL insert statement from dataframe
     sql_texts = []
+    # COPY table (column1, column2, ...) FROM '/path/to/data.csv' WITH (FORMAT CSV)
     for index, row in SOURCE.iterrows():
         cleaned_columns = [clean_column_name(col) for col in SOURCE.columns]
         sql_texts.append(
@@ -190,8 +193,9 @@ def SQL_INSERT_STATEMENT_FROM_DATAFRAME(SOURCE, TARGET):
 
 
 def populate_staging_table(bucket, s3_conn_id, postgres_conn, key):
+    logger = logging_mixin.LoggingMixin().logger()
     # Import table from S3 bucket to a pandas dataframe and convert to an array
-    print("Attempting to populate " + key)
+    logger.info("Attempting to populate " + key)
     hook = S3Hook(aws_conn_id=s3_conn_id)
     obj = hook.read_key(bucket_name=bucket, key=key)
     df = pd.read_csv(StringIO(obj))
@@ -208,6 +212,6 @@ def populate_staging_table(bucket, s3_conn_id, postgres_conn, key):
 
     # Build SQL code to insert data into table
     sqlQueryInsert = SQL_INSERT_STATEMENT_FROM_DATAFRAME(df, tablename)
-    print(sqlQueryInsert)
+    logger.debug(sqlQueryInsert)
     # run sqlQueryCreate in Postgres
-    execute_query(sqlQueryInsert, postgres_conn)
+    execute_query(sqlQueryInsert, postgres_conn, logger)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 wget
 apache-airflow-providers-amazon==7.4.1
+xlrd==2.0.2


### PR DESCRIPTION
List of current changes :
- Gov't data files updated.
  - All permit types added. Only 30 days back is available.
  - Building permit data has changed. Only 30 days back is available.
- Downloaded files are now placed in a separate temp directory.
- Temp directory cleared only at end of successful transformation/copying of download data.
- Classic Excel files are now converted to CSV format and uploaded.
- Text files are tested to see if they are valid CSV files. If so, they are renamed and uploaded.
- Moving from blind print statements to logging, with levels.
  - Debug levels used for table or SQL when possible.
  - No actual configuration of logging levels added at this time.
  
List of current bugfixes :
- Incorrect string manipulation of file paths fixed wherever found in downloading data.
- Column name generation is now consistent in staging upload.