### PR TITLE
Set up CI: ruff lint + DAG best-practice & integrity tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,75 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+# Cancel superseded runs on the same ref to save CI minutes.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PYTHON_VERSION: "3.12" # Matches the Python version in Astro Runtime 3.1.
+
+jobs:
+  lint:
+    name: Lint (ruff)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install dev dependencies
+        run: pip install -r requirements-dev.txt
+      - name: ruff check
+        run: ruff check dags include tests
+      - name: ruff format --check
+        run: ruff format --check dags include tests
+
+  static-dag-tests:
+    name: Static DAG policy tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install dev dependencies
+        run: pip install -r requirements-dev.txt
+      # These are pure-AST checks; they do not import or execute DAG files and
+      # do not need Airflow installed, so they give fast PR feedback.
+      - name: Run static DAG best-practice tests
+        run: |
+          pytest \
+            tests/test_duplicate_dag_ids.py \
+            tests/test_no_globals_injection.py \
+            tests/test_no_hardcoded_secrets.py \
+            tests/test_no_metadata_db_access.py \
+            tests/test_no_nested_loops.py \
+            tests/test_no_subdags.py \
+            tests/test_no_top_level_execution.py \
+            tests/test_non_deterministic_dag_ids.py \
+            tests/test_sensor_modes.py \
+            tests/test_static_start_date.py
+
+  runtime-dag-tests:
+    name: DAG integrity tests (Astro Runtime)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Building the project image both validates the Docker build and gives us
+      # an environment with Airflow + the project's providers installed.
+      - name: Build Astro Runtime image
+        run: docker build -t cdw-dag-tests .
+      # Runs the full suite inside the image: the existing DAG integrity tests,
+      # the DagBag-based best-practice tests (catchup, etc.), and the static
+      # tests. pytest is installed at runtime so it is never shipped to prod.
+      - name: Run DAG tests inside Astro Runtime
+        run: |
+          docker run --rm \
+            -e AIRFLOW_HOME=/usr/local/airflow \
+            cdw-dag-tests \
+            bash -lc "pip install --quiet pytest && pytest"

--- a/README.md
+++ b/README.md
@@ -126,8 +126,47 @@ Project Structure
 | `Dockerfile` | Astro Runtime image (currently `3.1-13`, based on Airflow 3.x) |
 | `docker-compose.override.yml` | CDW-specific services (LocalStack, CDW Postgres) and Airflow connection env vars |
 | `requirements.txt` | Python dependencies |
+| `requirements-dev.txt` | Dev/CI-only dependencies (`pytest`, `ruff`) — not installed into the runtime image |
 | `packages.txt` | OS-level packages |
+| `pyproject.toml` | Ruff (lint/format) and pytest configuration |
 | `airflow_settings.yaml.example` | Example Airflow connections and variables config |
+
+Continuous Integration
+======================
+
+CI runs on every pull request and on pushes to `master` via GitHub Actions
+(`.github/workflows/ci.yml`). There is no automated deploy yet — CI is a quality
+gate only. It has three jobs:
+
+| Job | What it does |
+|-----|--------------|
+| **Lint (ruff)** | `ruff check` + `ruff format --check` over `dags/`, `include/`, and `tests/`. Config lives in `pyproject.toml`. |
+| **Static DAG policy tests** | Pure-AST best-practice checks (no Airflow needed) — hardcoded secrets, top-level execution, non-deterministic DAG IDs, dynamic `start_date`, subdags, sensor modes, etc. |
+| **DAG integrity tests (Astro Runtime)** | Builds the project image (validating the Docker build) and runs the full `pytest` suite inside it, including the `DagBag`-based tests (import errors, tags, `retries >= 2`, `catchup=False`). |
+
+The DAG tests are adapted from Astronomer's
+[best_practices_pytests](https://github.com/astronomer/best_practices_pytests).
+Thresholds (task counts, sensor intervals, import-time limits) are tunable via
+environment variables documented in that repo. Import-timing and parse-profiling
+tests are opt-in and skipped by default.
+
+### Running checks locally
+
+```bash
+pip install -r requirements-dev.txt
+
+# Lint and auto-format
+ruff check dags include tests
+ruff format dags include tests
+
+# Static (no-Airflow) best-practice tests
+pytest tests/test_no_hardcoded_secrets.py tests/test_no_top_level_execution.py  # ...etc
+
+# Full suite inside the Astro Runtime image (matches the CI runtime job)
+docker build -t cdw-dag-tests .
+docker run --rm -e AIRFLOW_HOME=/usr/local/airflow cdw-dag-tests \
+  bash -lc "pip install --quiet pytest && pytest"
+```
 
 Deployment
 ==========

--- a/dags/create_cdw_databases.py
+++ b/dags/create_cdw_databases.py
@@ -1,6 +1,7 @@
-from datetime import datetime, timedelta
-from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 import os
+from datetime import datetime, timedelta
+
+from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 from airflow.sdk import DAG
 
 base_dir = os.path.dirname(os.path.realpath(__file__))
@@ -11,6 +12,9 @@ with DAG(
     start_date=datetime(2022, 12, 30),
     max_active_runs=1,
     schedule=None,
+    catchup=False,
+    tags=["setup"],
+    default_args={"retries": 2, "retry_delay": timedelta(minutes=1)},
     template_searchpath=[sql_dir, "include/sql"],
 ) as dag:
     # Create schema "staging" in cdw database
@@ -24,19 +28,19 @@ with DAG(
     create_current = SQLExecuteQueryOperator(
         task_id="create_data_prep",
         conn_id="cdw-dev",
-        sql=f"create_current.sql",
+        sql="create_current.sql",
     )
 
     # Create schema "history" in cdw database
     create_history = SQLExecuteQueryOperator(
         task_id="create_history",
         conn_id="cdw-dev",
-        sql=f"create_history.sql",
+        sql="create_history.sql",
     )
 
     create_truncate_tables_function = SQLExecuteQueryOperator(
         task_id="create_truncate_tables_function",
         conn_id="cdw-dev",
-        sql=f"create_truncate_tables_function.sql",
+        sql="create_truncate_tables_function.sql",
     )
 create_staging >> create_current >> create_history >> create_truncate_tables_function

--- a/dags/dag_parsing_survey.py
+++ b/dags/dag_parsing_survey.py
@@ -1,8 +1,9 @@
-from airflow.models import DagBag
-from datetime import datetime, timedelta
 import time
-from airflow.sdk import DAG
+from datetime import datetime, timedelta
+
+from airflow.models import DagBag
 from airflow.providers.standard.operators.python import PythonOperator
+from airflow.sdk import DAG
 
 
 def survey_dag_parsing_times(**kwargs):
@@ -39,7 +40,7 @@ default_args = {
     "start_date": datetime(2023, 1, 1),
     "email_on_failure": False,
     "email_on_retry": False,
-    "retries": 1,
+    "retries": 2,
     "retry_delay": timedelta(minutes=5),
 }
 
@@ -49,6 +50,7 @@ with DAG(
     description="A DAG to survey DAG parsing times",
     schedule=timedelta(days=1),
     catchup=False,
+    tags=["utility"],
 ) as dag:
     survey_task = PythonOperator(
         task_id="survey_dag_parsing_times_task",

--- a/dags/govt_file_download.py
+++ b/dags/govt_file_download.py
@@ -1,3 +1,11 @@
+import json
+from datetime import datetime, timedelta
+
+from airflow.providers.standard.operators.python import PythonOperator
+from airflow.sdk import DAG, task_group
+
+from include.retrieve_gov_file import clear_files_and_subdirs, retrieve_gov_file
+
 doc_md_DAG = """
 ### govt_file_download
 
@@ -8,13 +16,6 @@ Currently converts the following file formats. All others are loaded to s3 after
 
 
 """
-
-
-import json
-from datetime import datetime, timedelta
-from airflow.sdk import DAG, task_group
-from airflow.providers.standard.operators.python import PythonOperator
-from include.retrieve_gov_file import retrieve_gov_file, clear_files_and_subdirs
 
 gov_files = "include/gov_files.json"
 BUCKET = "civic-data-warehouse-lz"
@@ -28,6 +29,7 @@ with DAG(
     start_date=datetime(2022, 6, 24),
     catchup=False,
     doc_md=doc_md_DAG,
+    tags=["ingestion"],
     default_args={"retries": 3, "retry_delay": timedelta(minutes=1)},
 ) as dag:
 
@@ -36,8 +38,8 @@ with DAG(
         with open(gov_files, "r") as read_file:
             gov_file_data = json.load(read_file)
             for file in gov_file_data["gov_files"]:
-                task_id="files_to_s3_" + file["file_name"]
-                upload_file = PythonOperator(
+                task_id = "files_to_s3_" + file["file_name"]
+                PythonOperator(
                     task_id=task_id,
                     python_callable=retrieve_gov_file,
                     op_kwargs={
@@ -46,16 +48,14 @@ with DAG(
                         "bucket": BUCKET,
                         "s3_conn_id": "s3_datalake",
                         "task_id": task_id,
-                        "base_prep_dir": prep_directory
+                        "base_prep_dir": prep_directory,
                     },
                 )
 
     cleanup_task = PythonOperator(
-        task_id='clear_tmp_directory',
+        task_id="clear_tmp_directory",
         python_callable=clear_files_and_subdirs,
-        op_kwargs={
-            "dir_to_clear": prep_directory
-        },
+        op_kwargs={"dir_to_clear": prep_directory},
     )
 
     upload_all_files() >> cleanup_task

--- a/dags/secret_manager_test.py
+++ b/dags/secret_manager_test.py
@@ -1,8 +1,7 @@
-from datetime import datetime
-from airflow.sdk import DAG
-from airflow.sdk import BaseHook
-from airflow.sdk import Variable
+from datetime import datetime, timedelta
+
 from airflow.providers.standard.operators.python import PythonOperator
+from airflow.sdk import DAG, BaseHook, Variable
 
 
 def print_var():
@@ -14,6 +13,11 @@ def print_var():
 
 
 with DAG(
-    "example_secrets_dag", start_date=datetime(2022, 1, 1), schedule=None
+    "example_secrets_dag",
+    start_date=datetime(2022, 1, 1),
+    schedule=None,
+    catchup=False,
+    tags=["utility"],
+    default_args={"retries": 2, "retry_delay": timedelta(minutes=1)},
 ) as dag:
     test_task = PythonOperator(task_id="test-task", python_callable=print_var)

--- a/dags/sql_test.py
+++ b/dags/sql_test.py
@@ -1,9 +1,16 @@
 from datetime import datetime, timedelta
+
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 from airflow.sdk import DAG
 
 with DAG(
-    "sql_test", start_date=datetime(2022, 12, 30), max_active_runs=1, schedule=None
+    "sql_test",
+    start_date=datetime(2022, 12, 30),
+    max_active_runs=1,
+    schedule=None,
+    catchup=False,
+    tags=["utility"],
+    default_args={"retries": 2, "retry_delay": timedelta(minutes=1)},
 ) as dag:
     truncate_staging = SQLExecuteQueryOperator(
         task_id="sql_test",

--- a/dags/staging_table_prep.py
+++ b/dags/staging_table_prep.py
@@ -1,18 +1,18 @@
+import os
+from datetime import datetime, timedelta
+
+from airflow.providers.amazon.aws.operators.s3 import S3ListOperator
+from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
+from airflow.providers.standard.operators.python import PythonOperator
+from airflow.sdk import DAG
+
+from include.staging_table_prep import create_staging_table, populate_staging_table
+
 doc_md_DAG = """
-### govt_file_download
+### staging_table_prep
 
 This dag truncates any existing tables in the staging schema, the creates a table for any file found in the s3 bucket.
 """
-
-from datetime import datetime, timedelta
-from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
-from airflow.providers.amazon.aws.operators.s3 import S3ListOperator
-from airflow.sdk import TaskGroup
-import os
-from include.staging_table_prep import create_staging_table, populate_staging_table
-from airflow.sdk import DAG
-from airflow.providers.standard.operators.python import PythonOperator
-
 
 base_dir = os.path.dirname(os.path.realpath(__file__))
 sql_dir = os.path.join(base_dir, "sql")
@@ -31,13 +31,16 @@ with DAG(
     start_date=datetime(2022, 12, 30),
     max_active_runs=1,
     schedule=None,
+    catchup=False,
     doc_md=doc_md_DAG,
+    tags=["staging"],
+    default_args={"retries": 2, "retry_delay": timedelta(minutes=1)},
     template_searchpath=[sql_dir, "include/sql"],
 ) as dag:
     truncate_staging = SQLExecuteQueryOperator(
         task_id="truncate_staging",
         conn_id="cdw-dev",
-        sql=f"truncate_schema.sql",
+        sql="truncate_schema.sql",
         params={"schema": "staging"},
     )
 

--- a/include/check_urls.py
+++ b/include/check_urls.py
@@ -26,7 +26,9 @@ def _sniff(name: str, content_type: str | None, sample: bytes) -> str:
     if lowered.startswith(b"<!doctype html") or lowered.startswith(b"<html"):
         return "looks like HTML (not data)"
 
-    if name.lower().endswith(".zip") or (content_type or "").lower().startswith("application/zip"):
+    if name.lower().endswith(".zip") or (content_type or "").lower().startswith(
+        "application/zip"
+    ):
         return "zip signature OK" if sample.startswith(b"PK") else "not a ZIP signature"
 
     if name.lower().endswith(".csv") or "csv" in (content_type or "").lower():
@@ -69,7 +71,9 @@ for entry in data["gov_files"]:
     sample = b""
     get_status: int | str = "?"
     try:
-        get_req = urllib.request.Request(url, method="GET", headers={"Range": "bytes=0-2047"})
+        get_req = urllib.request.Request(
+            url, method="GET", headers={"Range": "bytes=0-2047"}
+        )
         with urllib.request.urlopen(get_req, timeout=20, context=ssl_ctx) as r:
             get_status = r.status
             final_url = r.geturl()

--- a/include/process_parcel_data.py
+++ b/include/process_parcel_data.py
@@ -1,36 +1,42 @@
-from sqlalchemy import create_engine
-import urllib.parse
-import psycopg2
-import subprocess
-import os
-import pandas as pd
-import numpy as np
-import re
 import csv
-from dateutil.parser import parse as parse_date
-from datetime import datetime
+import json
+import os
+import re
+import subprocess
 import tempfile
+import urllib.parse
+from datetime import datetime
 from pathlib import Path
 
-from dashboard.code.core.paths import (
-    CITY_PARCELS_FILE, COUNTY_PARCELS_FILE, CITY_PARCEL_DATA_FILE, CREDENTIALS_DIR)
+import numpy as np
+import pandas as pd
+import psycopg2
 from dashboard.code.backend.project_root.config.env import ENV
-import json
+from dashboard.code.core.paths import (
+    CITY_PARCEL_DATA_FILE,
+    CITY_PARCELS_FILE,
+    COUNTY_PARCELS_FILE,
+    CREDENTIALS_DIR,
+)
+from dateutil.parser import parse as parse_date
 
 CREDENTIALS_FILE = CREDENTIALS_DIR / f"{ENV}.json"
 
+
 def get_db_credentials():
-    with open(CREDENTIALS_FILE, 'r') as f:
+    with open(CREDENTIALS_FILE, "r") as f:
         return json.load(f)
+
 
 credentials = get_db_credentials()
 
 # Direct usage without encoding
-raw_user = credentials['DB_USER']
-raw_password = credentials['DB_PASS']
-raw_host = credentials['DB_HOST']
-raw_port = credentials['DB_PORT']
-raw_db_name = credentials['DB_NAME']
+raw_user = credentials["DB_USER"]
+raw_password = credentials["DB_PASS"]
+raw_host = credentials["DB_HOST"]
+raw_port = credentials["DB_PORT"]
+raw_db_name = credentials["DB_NAME"]
+
 
 def connect_with_cursor():
     conn = psycopg2.connect(
@@ -38,17 +44,21 @@ def connect_with_cursor():
         user=raw_user,
         password=raw_password,
         host=raw_host,
-        port=raw_port
+        port=raw_port,
     )
     return conn, conn.cursor()
 
+
 def safe_pg_identifier(name):
     # Replace unsafe characters with underscores and lowercase
-    return re.sub(r'\W|^(?=\d)', '_', name).lower()
+    return re.sub(r"\W|^(?=\d)", "_", name).lower()
+
 
 def create_temp_table_sql(table_name, schema):
     table_name = table_name.lower()
-    cols_sql = ",\n  ".join([f"{safe_pg_identifier(col)} {dtype}" for col, dtype in schema])
+    cols_sql = ",\n  ".join(
+        [f"{safe_pg_identifier(col)} {dtype}" for col, dtype in schema]
+    )
     return f"CREATE TEMP TABLE {table_name} (\n  {cols_sql}\n);"
 
 
@@ -68,130 +78,142 @@ def remove_commas_from_numeric_fields(df):
 
 
 def infer_schema_from_csv(csv_path, sample_size=100, force_text_cols=None):
-    # Note: this methodology looks at individual values throughout each column. An alternate method would create a series of 
+    # Note: this methodology looks at individual values throughout each column. An alternate method would create a series of
     # unique values within each column, first. However, this would require more memory and compute power.
     if force_text_cols is None:
         force_text_cols = []
 
     def is_boolean(val):
         val = str(val).strip().lower()
-        return val in {'true', 'false', 'yes', 'no'}
-    
+        return val in {"true", "false", "yes", "no"}
+
     def is_integer(val):
         try:
-            val_clean = val.replace(',', '').strip()
+            val_clean = val.replace(",", "").strip()
             int(val_clean)
             return True
-        except:
+        except Exception:
             return False
-        
+
     def is_float(val):
         try:
-            val_clean = val.replace(',', '').strip()
+            val_clean = val.replace(",", "").strip()
             float(val_clean)
             return True
-        except:
+        except Exception:
             return False
-    
+
     def is_date(val):
         try:
             parse_date(val, fuzzy=False)
             return True
-        except:
+        except Exception:
             return False
-        
+
     def is_timestamp(val):
         try:
             dt = parse_date(val, fuzzy=False)
             return dt.time() != datetime.min.time()
-        except:
+        except Exception:
             return False
 
-    # Read and clean the data    
+    # Read and clean the data
     df = pd.read_csv(csv_path, dtype=str)
     df_cleaned = remove_commas_from_numeric_fields(df)
 
     # Save cleaned DataFrame to a temp file
-    tmp_file = tempfile.NamedTemporaryFile(mode='w', newline='', suffix='.csv', delete=False)
+    tmp_file = tempfile.NamedTemporaryFile(
+        mode="w", newline="", suffix=".csv", delete=False
+    )
     cleaned_csv_path = tmp_file.name
     tmp_file.close()  # Close the file before writing
 
     df_cleaned.to_csv(cleaned_csv_path, index=False)
 
-    with open(cleaned_csv_path, newline='', encoding='utf-8') as csvfile:
+    with open(cleaned_csv_path, newline="", encoding="utf-8") as csvfile:
         reader = csv.DictReader(csvfile)
         samples = [row for _, row in zip(range(sample_size), reader)]
 
         if not samples:
             raise ValueError("CSV file is empty or header missing.")
-        
+
         schema = []
         for field in reader.fieldnames:
             if not field.strip():
                 continue  # skip blank field names
 
             normalized_field = field.strip().lower()
-            normalized_force_text_cols = [col.strip().lower() for col in force_text_cols]
+            normalized_force_text_cols = [
+                col.strip().lower() for col in force_text_cols
+            ]
 
             if normalized_field in normalized_force_text_cols:
-                schema.append((field, 'TEXT'))
+                schema.append((field, "TEXT"))
                 continue
-            
+
             # Infer type based on sample values
-            values = [row[field] for row in samples if row[field] != '']
-            
+            values = [row[field] for row in samples if row[field] != ""]
+
             # Filter out null values
-            non_null_values = [v for v in values if v not in (None, '', 'null', 'NULL')]
+            non_null_values = [v for v in values if v not in (None, "", "null", "NULL")]
 
             if len(non_null_values) == 0:
-                schema.append((field, 'TEXT'))
+                schema.append((field, "TEXT"))
                 continue
 
             if all(is_boolean(v) for v in non_null_values):
-                schema.append((field, 'BOOLEAN'))
+                schema.append((field, "BOOLEAN"))
             elif all(is_float(v) for v in non_null_values):
-                schema.append((field, 'DOUBLE PRECISION'))
+                schema.append((field, "DOUBLE PRECISION"))
             elif all(is_integer(v) for v in non_null_values):
                 try:
                     if all(-2147483648 <= int(v) < 2147483647 for v in non_null_values):
-                        schema.append((field, 'INTEGER'))
+                        schema.append((field, "INTEGER"))
                     else:
-                        schema.append((field, 'BIGINT'))
+                        schema.append((field, "BIGINT"))
                 except ValueError:
-                    schema.append((field, 'TEXT'))
+                    schema.append((field, "TEXT"))
             elif all(is_integer(v) or is_float(v) for v in non_null_values):
-                schema.append((field, 'DOUBLE PRECISION'))
+                schema.append((field, "DOUBLE PRECISION"))
             elif all(is_timestamp(v) for v in non_null_values):
-                schema.append((field, 'TIMESTAMP'))
+                schema.append((field, "TIMESTAMP"))
             elif all(is_date(v) for v in non_null_values):
-                schema.append((field, 'DATE'))
+                schema.append((field, "DATE"))
             else:
-                schema.append((field, 'TEXT'))
+                schema.append((field, "TEXT"))
 
     return schema, cleaned_csv_path
 
 
-def merge_table_with_csv(conn, cursor, merged_table, temp_table, csv_path, target_table, target_col, temp_col):
+def merge_table_with_csv(
+    conn, cursor, merged_table, temp_table, csv_path, target_table, target_col, temp_col
+):
     # 1. Load CSV into a temp table
     csv_path = Path(csv_path)
     try:
-        with csv_path.open('r') as f:
-            cursor.copy_expert(f"""
+        with csv_path.open("r") as f:
+            cursor.copy_expert(
+                f"""
             COPY {temp_table} FROM STDIN WITH (FORMAT CSV, HEADER, DELIMITER ',', QUOTE '"');
-            """, f)
+            """,
+                f,
+            )
     except Exception as e:
         print(f"Failed to load CSV into temp table: {e}")
         conn.rollback()
         raise
 
     # 2. Get temp table columns excluding join key
-    cursor.execute(f"""
-        SELECT column_name FROM information_schema.columns 
+    cursor.execute(
+        """
+        SELECT column_name FROM information_schema.columns
         WHERE table_name = %s AND column_name != %s;
-    """, (temp_table, temp_col))
+    """,
+        (temp_table, temp_col),
+    )
     temp_cols = [row[0] for row in cursor.fetchall()]
 
-    temp_cols_sql = ', '.join([f's.{col}' for col in temp_cols])
+    temp_cols_sql = ", ".join([f"s.{col}" for col in temp_cols])
 
     query = f"""
         DROP TABLE IF EXISTS {merged_table};
@@ -215,11 +237,11 @@ def merge_table_with_csv(conn, cursor, merged_table, temp_table, csv_path, targe
 
 def encode_credentials(credentials):
     # Function to URL-encode credentials
-    user = urllib.parse.quote(credentials['DB_USER'])
-    password = urllib.parse.quote(credentials['DB_PASS'])
-    host = credentials['DB_HOST']
-    port = credentials['DB_PORT']
-    database = credentials['DB_NAME']
+    user = urllib.parse.quote(credentials["DB_USER"])
+    password = urllib.parse.quote(credentials["DB_PASS"])
+    host = credentials["DB_HOST"]
+    port = credentials["DB_PORT"]
+    database = credentials["DB_NAME"]
     return user, password, host, port, database
 
 
@@ -229,35 +251,45 @@ def shapefile_to_DB(shapefile_path: Path):
 
     shp2pgsql = subprocess.Popen(
         ["shp2pgsql", "-I", "-s", "4326", "-d", shapefile_path, f"public.{table_name}"],
-        stdout=subprocess.PIPE
+        stdout=subprocess.PIPE,
     )
 
     env = os.environ.copy()
     env["PGPASSWORD"] = urllib.parse.unquote(password)  # decode for shell usage
 
     psql = subprocess.Popen(
-        ["psql", "-U", urllib.parse.unquote(user), "-h", host, "-p", port, "-d", database],
+        [
+            "psql",
+            "-U",
+            urllib.parse.unquote(user),
+            "-h",
+            host,
+            "-p",
+            port,
+            "-d",
+            database,
+        ],
         stdin=shp2pgsql.stdout,
-        env=env
+        env=env,
     )
 
-    shp2pgsql.stdout.close() # Allow shp2pgsql to receive a SIGPIPE if psql exits
+    shp2pgsql.stdout.close()  # Allow shp2pgsql to receive a SIGPIPE if psql exits
     psql.communicate()
-    
 
-def get_srid(cursor, table, column='geom'):
+
+def get_srid(cursor, table, column="geom"):
     query = f"SELECT Find_SRID('public', '{table}', '{column}');"
     cursor.execute(query)
     return cursor.fetchone()[0]
 
 
 def crs_transform(conn, cursor, table, target_srid):
-        cursor.execute(f"""
+    cursor.execute(f"""
         ALTER TABLE {table}
         ALTER COLUMN geom TYPE geometry(MULTIPOLYGON, {target_srid})
         USING ST_Transform(geom, {target_srid});
         """)
-        conn.commit()
+    conn.commit()
 
 
 def reproject_parcels(conn, cursor, geotable, srid):
@@ -272,20 +304,20 @@ def reproject_parcels(conn, cursor, geotable, srid):
 
 
 def create_all_parcels(cursor):
-    cursor.execute(f"""
+    cursor.execute("""
         CREATE TABLE all_parcels AS
-        SELECT 
+        SELECT
             geom, parcel_id, prop_add, prop_zip, municipali, county,
             asstlandva, asstimpval, totassmt, propclass, zoning, yearblt
         FROM (
-            SELECT 
+            SELECT
                 geom, parcel_id, prop_add, prop_zip, municipali, county,
                 asstlandva, asstimpval, totassmt, propclass, zoning, yearblt
             FROM city_parcels
 
             UNION ALL
 
-            SELECT 
+            SELECT
                 geom, parcel_id, prop_add, prop_zip, municipali, county,
                 asstlandva, asstimpval, totassmt, propclass, zoning, yearblt
             FROM county_parcels
@@ -298,7 +330,7 @@ def create_all_parcels(cursor):
 def deduplicate_parcels(cursor):
     # De-duplicate parcel_ids in all_parcels
     # Step 1: Create deduplicated table
-    cursor.execute(f"""
+    cursor.execute("""
     CREATE TABLE deduped_parcels AS
     SELECT
         parcel_id,
@@ -313,7 +345,7 @@ def deduplicate_parcels(cursor):
         STRING_AGG(DISTINCT propclass, ', ') AS propclass,
         STRING_AGG(DISTINCT zoning, ', ') AS zoning,
         MAX(yearblt) AS yearblt
-               
+
     FROM all_parcels
     GROUP BY parcel_id;
     """)
@@ -329,9 +361,8 @@ def deduplicate_parcels(cursor):
     print("PRIMARY KEY added to all_parcels.")
 
 
-
 def main():
-## PART I.
+    ## PART I.
     # Read file directories from config
     city_shapefile = CITY_PARCELS_FILE
     county_shapefile = COUNTY_PARCELS_FILE
@@ -356,8 +387,7 @@ def main():
     cursor.close()
     conn.close()
 
-
-## PART II.
+    ## PART II.
     # Merge City Attributes w/ City Parcel geometry
     city_csv_path = CITY_PARCEL_DATA_FILE
 
@@ -365,33 +395,34 @@ def main():
     conn, cursor = connect_with_cursor()
 
     schema, clean_csv_path = infer_schema_from_csv(
-        city_csv_path, 
-        force_text_cols=
-        ['handle', 
-         'asrparcelid', 
-         'colparcelid', 
-         'addrtype', 
-         'parcelid', 
-         'natregsite', 
-         'zip', 
-         'ownerzip',
-         'cityblock',
-         'giscityblock',
-         ])
-    create_sql = create_temp_table_sql('city_attr', schema)
+        city_csv_path,
+        force_text_cols=[
+            "handle",
+            "asrparcelid",
+            "colparcelid",
+            "addrtype",
+            "parcelid",
+            "natregsite",
+            "zip",
+            "ownerzip",
+            "cityblock",
+            "giscityblock",
+        ],
+    )
+    create_sql = create_temp_table_sql("city_attr", schema)
     print(create_sql)
     cursor.execute(create_sql)
 
     try:
         merge_table_with_csv(
-            conn, 
+            conn,
             cursor,
-            merged_table='city_parcels_attr',
-            temp_table='city_attr',
+            merged_table="city_parcels_attr",
+            temp_table="city_attr",
             csv_path=clean_csv_path,
-            target_table='city_parcels',
-            target_col='handle',
-            temp_col='handle'
+            target_table="city_parcels",
+            target_col="handle",
+            temp_col="handle",
         )
     finally:
         if os.path.exists(clean_csv_path):
@@ -400,10 +431,11 @@ def main():
     cursor.close()
     conn.close()
 
-## PART III.
+    ## PART III.
     # Merge city_parcels and county_parcels into all_parcels
     create_all_parcels(cursor)
     deduplicate_parcels(cursor)
+
 
 if __name__ == "__main__":
     main()

--- a/include/retrieve_gov_file.py
+++ b/include/retrieve_gov_file.py
@@ -1,8 +1,11 @@
-import subprocess, os
-import shutil, wget
-import pandas
-from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+import os
+import shutil
+import subprocess
 from zipfile import ZipFile
+
+import pandas
+import wget
+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.utils.log import logging_mixin
 
 
@@ -31,7 +34,7 @@ def _csv_passes_strict_parse(path: str, logger) -> bool:
 
 def retrieve_gov_file(filename, file_url, bucket, s3_conn_id, task_id, base_prep_dir):
     """
-    Downloads a single file to a temporary directory, recursively unzips it, converts .mdb files if needed, 
+    Downloads a single file to a temporary directory, recursively unzips it, converts .mdb files if needed,
      and uploads it to s3
     :return: none
     """
@@ -46,7 +49,7 @@ def retrieve_gov_file(filename, file_url, bucket, s3_conn_id, task_id, base_prep
     else:
         logger.info(f"Moving {download_dest} into {prep_dir} directory")
         shutil.move(download_dest, prep_dir)
-        
+
     for file in os.listdir(prep_dir):
         logger.info(f"{file} found in {prep_dir} for sending to S3")
         if file.endswith(".mdb"):
@@ -72,13 +75,13 @@ def build_temp_subdirectory(task_id, base_prep_dir, logger):
     safe_dirname = "".join(char for char in task_id if char.isalnum())
     prep_dir = os.path.join(base_prep_dir, safe_dirname[:99])
     logger.info(f"using tmp directory '{prep_dir}'")
-        
+
     if not os.path.exists(prep_dir):
         logger.info(f"Creating directory {prep_dir}")
         os.makedirs(prep_dir)
 
     clear_files_and_subdirs(prep_dir)
-    
+
     return prep_dir
 
 
@@ -107,12 +110,15 @@ def unpack_zip(path_to_zip, extract_path, logger):
         try:
             if name.endswith(".zip"):
                 inner_zipfile = os.path.join(extract_path, name)
-                unpack_zip(path_to_zip=inner_zipfile, extract_path=extract_path, logger=logger)
+                unpack_zip(
+                    path_to_zip=inner_zipfile, extract_path=extract_path, logger=logger
+                )
                 os.remove(inner_zipfile)
                 logger.info(f"{name} successfully unzipped")
-        except:
-            logger.error(f"{name} is not a .zip - full path : {os.path.join(extract_path, name)}")
-            pass
+        except Exception:
+            logger.error(
+                f"{name} is not a .zip - full path : {os.path.join(extract_path, name)}"
+            )
 
 
 def upload_to_s3(bucket, s3_conn_id, logger, file, prep_dir):
@@ -122,7 +128,9 @@ def upload_to_s3(bucket, s3_conn_id, logger, file, prep_dir):
     """
     key = file.replace(" ", "")
     source_file = os.path.join(prep_dir, file)
-    if file.lower().endswith(".csv") and not _csv_passes_strict_parse(source_file, logger):
+    if file.lower().endswith(".csv") and not _csv_passes_strict_parse(
+        source_file, logger
+    ):
         try:
             os.remove(source_file)
         except OSError as e:
@@ -132,7 +140,9 @@ def upload_to_s3(bucket, s3_conn_id, logger, file, prep_dir):
     logger.info(f"Moving {source_file} into s3 bucket {bucket}")
     s3_hook = S3Hook(aws_conn_id=s3_conn_id)
     s3_hook.load_file(filename=source_file, key=key, bucket_name=bucket, replace=True)
-    logger.info(f"{source_file} successfully uploaded to s3 in bucket {bucket} and with key {key}")
+    logger.info(
+        f"{source_file} successfully uploaded to s3 in bucket {bucket} and with key {key}"
+    )
     logger.info(f"{file} successfully loaded to S3")
 
 
@@ -164,6 +174,7 @@ def export_xls_file(bucket, s3_conn_id, logger, file, prep_dir):
     logger.info(f"loaded {prepped_file} and written all data to {full_csv_filename}")
     upload_to_s3(bucket, s3_conn_id, logger, csv_filename, prep_dir)
 
+
 def export_mdb_file(bucket, s3_conn_id, logger, file, prep_dir):
     """
     Strip all tables in an .mdb file into separate .csv files. Upload the resulting .csv files to S3.
@@ -175,37 +186,37 @@ def export_mdb_file(bucket, s3_conn_id, logger, file, prep_dir):
         cmd_open_mdb = f"mdb-tables {prepped_file}"
         logger.info(f"executing command {cmd_open_mdb}")
         table_names = subprocess.Popen(
-                    cmd_open_mdb,
-                    stdout=subprocess.PIPE,
-                    shell=True,
-                )
+            cmd_open_mdb,
+            stdout=subprocess.PIPE,
+            shell=True,
+        )
         output = table_names.communicate()[0].decode("ascii")
         logger.debug(output)
         tables = output.split(" ")
         logger.debug(tables)
     except subprocess.CalledProcessError as e:
         raise RuntimeError(
-                    "command '{}' return with error (code {}): {}".format(
-                        e.cmd, e.returncode, e.output
-                    )
-                )
+            "command '{}' return with error (code {}): {}".format(
+                e.cmd, e.returncode, e.output
+            )
+        )
     for table in tables:
         if table != "" and table != "\n":
-            export_file = os.path.splitext(file)[0] + "_" + table.replace(" ", "_") + ".csv"
+            export_file = (
+                os.path.splitext(file)[0] + "_" + table.replace(" ", "_") + ".csv"
+            )
             export_fullpath = os.path.join(prep_dir, export_file)
             logger.info(f"Exporting {table} to {export_fullpath}")
             with open(export_fullpath, "wb") as f:
                 try:
-                    subprocess.check_call(
-                                ["mdb-export", prepped_file, table], stdout=f
-                            )
+                    subprocess.check_call(["mdb-export", prepped_file, table], stdout=f)
                 except subprocess.CalledProcessError as e:
                     raise RuntimeError(
-                                "command '{}' return with error (code {}): {}".format(
-                                    e.cmd, e.returncode, e.output
-                                )
-                            )
-                
+                        "command '{}' return with error (code {}): {}".format(
+                            e.cmd, e.returncode, e.output
+                        )
+                    )
+
             upload_to_s3(bucket, s3_conn_id, logger, export_file, prep_dir)
 
 

--- a/include/staging_table_prep.py
+++ b/include/staging_table_prep.py
@@ -1,13 +1,14 @@
-import os
 import logging
+import os
+import re
+from io import StringIO
 from logging import Logger
+
+import numpy as np
+import pandas as pd
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 from airflow.utils.log import logging_mixin
-import pandas as pd
-import numpy as np
-from io import StringIO
-import re
 
 
 def download_from_s3(key: str, bucket_name: str, s3_conn_id: str):
@@ -22,8 +23,10 @@ def download_from_s3(key: str, bucket_name: str, s3_conn_id: str):
     logger.info(filename + " renamed to " + download_dest + key)
 
 
-def execute_query(query, conn_id, logger:Logger):
-    hook = PostgresHook(postgres_conn_id=conn_id, log_sql=(logger.level==logging.DEBUG))
+def execute_query(query, conn_id, logger: Logger):
+    hook = PostgresHook(
+        postgres_conn_id=conn_id, log_sql=(logger.level == logging.DEBUG)
+    )
     hook.run(sql=query)
 
 
@@ -203,12 +206,10 @@ def populate_staging_table(bucket, s3_conn_id, postgres_conn, key):
         if df[column].dtype == object:
             df[column] = df[column].replace("'", "''", inplace=True)
     df.replace(np.nan, "None", inplace=True)
-    records = df.to_records(index=True)
 
     # Read table from S3 bucket
     filename = "/tmp/" + key
     tablename = filename.replace("/tmp/", "").replace(".csv", "").replace("-", "_")
-    columns = list(df.columns)
 
     # Build SQL code to insert data into table
     sqlQueryInsert = SQL_INSERT_STATEMENT_FROM_DATAFRAME(df, tablename)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[tool.ruff]
+# Astro Runtime 3.1 ships Python 3.12.
+target-version = "py312"
+line-length = 88
+# Astronomer-provided example DAGs are vendored scaffolding; don't lint them.
+extend-exclude = ["dags/examples"]
+
+[tool.ruff.lint]
+# E/W: pycodestyle, F: pyflakes, I: import sorting.
+select = ["E", "F", "I", "W"]
+# The formatter owns line length; it intentionally leaves long strings,
+# comments, and URLs unwrapped, so E501 is disabled per Ruff's guidance.
+ignore = ["E501"]
+
+[tool.ruff.lint.per-file-ignores]
+# Best-practice profiling tests intentionally set a module-level pytestmark
+# before importing the helpers they guard, which trips E402.
+"tests/test_dag_parse_profiling.py" = ["E402"]
+"tests/test_import_time_limit.py" = ["E402"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+# Quieter, deterministic output in CI.
+addopts = "-q"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+# Development / CI-only dependencies. These are NOT installed into the
+# Astro Runtime image (see requirements.txt for runtime deps).
+pytest>=8.0
+ruff==0.15.4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,45 @@
+# Shared fixtures and helpers for Airflow best-practices tests
+
+import ast
+from pathlib import Path
+
+import pytest
+
+# Resolve relative to this file so tests work from any working directory
+DAGS_DIR = (Path(__file__).parent.parent / "dags").resolve()
+
+
+def dag_files():
+    """Yield .py paths in DAGS_DIR, skipping __init__.py, dotfiles, and underscore-prefixed files."""
+    for py in sorted(DAGS_DIR.glob("*.py")):
+        if py.name.startswith((".", "_")):
+            continue
+        yield py
+
+
+def call_name(node: ast.Call) -> str:
+    """Return a best-effort dotted function name for an ast.Call node."""
+    if isinstance(node.func, ast.Name):
+        return node.func.id
+    if isinstance(node.func, ast.Attribute):
+        parts = []
+        cur = node.func
+        while isinstance(cur, ast.Attribute):
+            parts.append(cur.attr)
+            cur = cur.value
+        if isinstance(cur, ast.Name):
+            parts.append(cur.id)
+        return ".".join(reversed(parts))
+    return ""
+
+
+@pytest.fixture(scope="session")
+def generated_dags():
+    """Load all DAGs via DagBag and return a {dag_id: dag} mapping."""
+    try:
+        from airflow.models import DagBag
+    except ModuleNotFoundError:
+        pytest.skip("Airflow is required for DagBag-based tests")
+
+    bag = DagBag(dag_folder=str(DAGS_DIR), include_examples=False)
+    return bag.dags

--- a/tests/dags/test_dag_integrity.py
+++ b/tests/dags/test_dag_integrity.py
@@ -1,8 +1,9 @@
 """Test the validity of all DAGs. This test ensures that all Dags have tags, retries set to two, and no import errors. Feel free to add and remove tests."""
 
-import os
 import logging
+import os
 from contextlib import contextmanager
+
 import pytest
 from airflow.models import DagBag
 
@@ -78,6 +79,6 @@ def test_dag_retries(dag_id, dag, fileloc):
     """
     test if a DAG has retries set
     """
-    assert (
-        dag.default_args.get("retries", None) >= 2
-    ), f"{dag_id} in {fileloc} does not have retries not set to 2."
+    assert dag.default_args.get("retries", None) >= 2, (
+        f"{dag_id} in {fileloc} does not have retries not set to 2."
+    )

--- a/tests/test_catchup_disabled.py
+++ b/tests/test_catchup_disabled.py
@@ -1,0 +1,16 @@
+# Ensure catchup=False to avoid unintended backfills
+# This test ensures: DAGs with catchup=True can create massive backfills on first deployment.
+# Guidance: https://docs.astronomer.io/learn/dags
+
+
+def test_catchup_disabled(generated_dags):
+    violating = [
+        dag_id
+        for dag_id, dag in generated_dags.items()
+        if getattr(dag, "catchup", True)
+    ]
+    assert not violating, (
+        "The following DAGs have catchup=True (can create unintended backfills on first deploy): "
+        + ", ".join(sorted(violating))
+        + " — see Astronomer guidance: https://docs.astronomer.io/learn/dags"
+    )

--- a/tests/test_dag_parse_profiling.py
+++ b/tests/test_dag_parse_profiling.py
@@ -1,0 +1,131 @@
+# Per-statement import profiling for DAG files
+# This test ensures: When a DAG file is slow to import, the specific top-level
+# statement(s) responsible are identified with line numbers and timing.
+# Guidance: https://docs.astronomer.io/learn/dynamically-generating-dags
+
+import ast
+import importlib.util
+import os
+import sys
+import textwrap
+import time
+
+import pytest
+from conftest import dag_files
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("AIRFLOW_RUN_PARSE_PROFILING_TESTS") != "1",
+    reason="DAG parse profiling executes DAG files; set AIRFLOW_RUN_PARSE_PROFILING_TESTS=1 to run it",
+)
+
+# Per-statement threshold in seconds
+DEFAULT_STATEMENT_LIMIT_S = float(os.getenv("AIRFLOW_STATEMENT_TIME_LIMIT_S", "0.5"))
+
+# Overall file threshold — if the file imports fast, skip per-statement reporting
+DEFAULT_FILE_LIMIT_S = float(os.getenv("AIRFLOW_DAG_IMPORT_TIME_LIMIT_S", "1.0"))
+
+
+def _snippet(source_lines, lineno, end_lineno, max_lines=3):
+    """Return a short code snippet for the statement starting at lineno."""
+    start = lineno - 1  # 0-indexed
+    end = min(end_lineno, start + max_lines)
+    lines = source_lines[start:end]
+    snippet = "\n".join(lines)
+    if end_lineno > end:
+        snippet += "\n    ..."
+    return snippet
+
+
+def _profile_file(py_path):
+    """Instrument and exec a DAG file, returning per-statement timings.
+
+    Returns a list of (lineno, end_lineno, elapsed) for every top-level
+    statement, or None if the file cannot be parsed / executed.
+    """
+    source = py_path.read_text(encoding="utf-8", errors="ignore")
+    try:
+        tree = ast.parse(source, filename=str(py_path))
+    except SyntaxError:
+        return None
+
+    # We'll build a new module body that wraps each original statement
+    # with timing instrumentation.  The approach:
+    #   _t0 = time.perf_counter()
+    #   <original statement>
+    #   _timings.append((lineno, end_lineno, time.perf_counter() - _t0))
+    new_body = []
+
+    # Inject: import time as _time_mod; _timings = []
+    setup = ast.parse(
+        "import time as _time_mod\n_timings = []",
+        mode="exec",
+    ).body
+    new_body.extend(setup)
+
+    for node in tree.body:
+        lineno = node.lineno
+        end_lineno = getattr(node, "end_lineno", lineno) or lineno
+
+        # _t0 = _time_mod.perf_counter()
+        before = ast.parse("_t0 = _time_mod.perf_counter()", mode="exec").body[0]
+
+        # _timings.append((lineno, end_lineno, _time_mod.perf_counter() - _t0))
+        record_src = (
+            f"_timings.append(({lineno}, {end_lineno}, _time_mod.perf_counter() - _t0))"
+        )
+        after = ast.parse(record_src, mode="exec").body[0]
+
+        new_body.append(before)
+        new_body.append(node)
+        new_body.append(after)
+
+    tree.body = new_body
+    ast.fix_missing_locations(tree)
+
+    code = compile(tree, filename=str(py_path), mode="exec")
+
+    # Execute in an isolated module namespace
+    mod_name = f"_profmod_{py_path.stem}_{int(time.time() * 1000000)}"
+    spec = importlib.util.spec_from_file_location(mod_name, str(py_path))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+
+    try:
+        exec(code, module.__dict__)  # noqa: S102
+        timings = module.__dict__.get("_timings", [])
+    except Exception:
+        return None
+    finally:
+        sys.modules.pop(mod_name, None)
+
+    return timings
+
+
+def test_dag_parse_profiling():
+    """Flag specific top-level statements that exceed the per-statement time budget."""
+    slow_statements = []
+
+    for py in dag_files():
+        timings = _profile_file(py)
+        if timings is None:
+            continue  # parse/exec error — other tests catch this
+
+        total = sum(t[2] for t in timings)
+        if total <= DEFAULT_FILE_LIMIT_S:
+            continue  # file is fast overall, no need to report
+
+        source_lines = py.read_text(encoding="utf-8", errors="ignore").splitlines()
+
+        for lineno, end_lineno, elapsed in timings:
+            if elapsed > DEFAULT_STATEMENT_LIMIT_S:
+                snippet = _snippet(source_lines, lineno, end_lineno)
+                slow_statements.append(
+                    f"  {py.name}:{lineno} ({elapsed:.3f}s)\n"
+                    f"    {textwrap.indent(snippet, '    ').strip()}"
+                )
+
+    assert not slow_statements, (
+        "Slow top-level statements detected during DAG import. "
+        f"Per-statement limit: {DEFAULT_STATEMENT_LIMIT_S:.2f}s, "
+        f"file threshold: {DEFAULT_FILE_LIMIT_S:.2f}s.\n" + "\n".join(slow_statements)
+    )

--- a/tests/test_duplicate_dag_ids.py
+++ b/tests/test_duplicate_dag_ids.py
@@ -1,0 +1,89 @@
+# Detect duplicate DAG IDs across files
+# This test ensures: Duplicate DAG IDs can cause one DAG to overwrite another and disappear from the UI.
+# References:
+# - Airflow DAGs & IDs: https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/dags.html
+
+import ast
+from collections import defaultdict
+
+from conftest import call_name, dag_files
+
+
+def _module_string_constants(tree):
+    constants = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        if (
+            isinstance(target, ast.Name)
+            and isinstance(node.value, ast.Constant)
+            and isinstance(node.value.value, str)
+        ):
+            constants[target.id] = node.value.value
+    return constants
+
+
+def _string_value(node, constants):
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Name):
+        return constants.get(node.id)
+    return None
+
+
+def _dag_id_from_call(node: ast.Call, constants):
+    for keyword in node.keywords:
+        if keyword.arg == "dag_id":
+            return _string_value(keyword.value, constants)
+
+    if node.args:
+        return _string_value(node.args[0], constants)
+
+    return None
+
+
+def _find_declared_dag_ids(py_path):
+    text = py_path.read_text(encoding="utf-8", errors="ignore")
+    try:
+        tree = ast.parse(text, filename=str(py_path))
+    except SyntaxError:
+        return []
+
+    constants = _module_string_constants(tree)
+    dag_ids = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and call_name(node).endswith("DAG"):
+            dag_id = _dag_id_from_call(node, constants)
+            if dag_id:
+                dag_ids.append(dag_id)
+
+        if isinstance(node, ast.FunctionDef):
+            for decorator in node.decorator_list:
+                if isinstance(decorator, ast.Call) and call_name(decorator).endswith(
+                    "dag"
+                ):
+                    dag_ids.append(_dag_id_from_call(decorator, constants) or node.name)
+                elif isinstance(decorator, ast.Name) and decorator.id == "dag":
+                    dag_ids.append(node.name)
+
+    return dag_ids
+
+
+def test_duplicate_dag_ids_across_files():
+    dag_id_to_files = defaultdict(list)
+
+    for py in dag_files():
+        for dag_id in _find_declared_dag_ids(py):
+            dag_id_to_files[dag_id].append(str(py))
+
+    duplicates = {
+        dag_id: files for dag_id, files in dag_id_to_files.items() if len(files) > 1
+    }
+    assert not duplicates, (
+        "Duplicate DAG IDs detected (a later file will overwrite the earlier one in the UI):\n"
+        + "\n".join(
+            f"  {dag_id}: {', '.join(sorted(files))}"
+            for dag_id, files in sorted(duplicates.items())
+        )
+    )

--- a/tests/test_import_time_limit.py
+++ b/tests/test_import_time_limit.py
@@ -1,0 +1,47 @@
+# Avoid slow imports due to heavy logic
+# This test ensures: Heavy logic at DAG parse time can delay the scheduler; move work into tasks.
+# Guidance: https://docs.astronomer.io/learn/dynamically-generating-dags
+
+import importlib.util
+import os
+import sys
+import time
+
+import pytest
+from conftest import dag_files
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("AIRFLOW_RUN_IMPORT_TIMING_TESTS") != "1",
+    reason="DAG import timing tests execute DAG files; set AIRFLOW_RUN_IMPORT_TIMING_TESTS=1 to run them",
+)
+
+# Default per-file budget in seconds; can be overridden for CI via env
+DEFAULT_LIMIT_S = float(os.getenv("AIRFLOW_DAG_IMPORT_TIME_LIMIT_S", "1.0"))
+
+
+def _timed_import(py_path) -> float:
+    """Import a module from a path with a unique name and return elapsed seconds."""
+    name = f"_dagmod_{py_path.stem}_{int(time.time() * 1000000)}"
+    spec = importlib.util.spec_from_file_location(name, str(py_path))
+    module = importlib.util.module_from_spec(spec)
+    start = time.perf_counter()
+    spec.loader.exec_module(module)  # type: ignore[attr-defined]
+    elapsed = time.perf_counter() - start
+    sys.modules.pop(name, None)
+    return elapsed
+
+
+def test_import_time_limit_per_file():
+    slow = []
+    for py in dag_files():
+        try:
+            elapsed = _timed_import(py)
+            if elapsed > DEFAULT_LIMIT_S:
+                slow.append((py.name, elapsed))
+        except Exception as e:
+            slow.append((py.name, f"import error: {e}"))
+    assert not slow, (
+        "DAG import too slow or error-prone. Per-file limit is "
+        f"{DEFAULT_LIMIT_S:.2f}s. Offenders:\n"
+        + "\n".join(f"  {name}: {elapsed}" for name, elapsed in slow)
+    )

--- a/tests/test_no_globals_injection.py
+++ b/tests/test_no_globals_injection.py
@@ -1,0 +1,68 @@
+# Avoid use of globals() to register DAGs
+# This test ensures: Using globals() to inject DAGs hides structure, confuses linters, and makes imports fragile.
+# Guidance: prefer returning/collecting DAG objects explicitly or using module-level variables without globals().
+# See also: https://docs.astronomer.io/learn/dynamically-generating-dags
+
+import ast
+
+from conftest import dag_files
+
+
+def _detect_globals_injection(py_path):
+    """Return a list of (lineno, col, kind) where the file assigns via globals()[...] = ... or calls globals() in assignment."""
+    text = py_path.read_text(encoding="utf-8", errors="ignore")
+    violations = []
+    try:
+        tree = ast.parse(text, filename=str(py_path))
+    except Exception:
+        return violations
+
+    class Visitor(ast.NodeVisitor):
+        def visit_Assign(self, node: ast.Assign):
+            for tgt in node.targets:
+                if isinstance(tgt, ast.Subscript) and isinstance(tgt.value, ast.Call):
+                    call = tgt.value
+                    if isinstance(call.func, ast.Name) and call.func.id == "globals":
+                        violations.append(
+                            (
+                                node.lineno,
+                                node.col_offset,
+                                "assign_to_globals_subscript",
+                            )
+                        )
+            self.generic_visit(node)
+
+        def visit_Call(self, node: ast.Call):
+            if isinstance(node.func, ast.Name) and node.func.id == "globals":
+                violations.append((node.lineno, node.col_offset, "call_globals"))
+            self.generic_visit(node)
+
+    Visitor().visit(tree)
+
+    # De-duplicate: if both assign_to_globals_subscript and call_globals on same line, keep the assign variant
+    dedup = {}
+    for lineno, col, kind in violations:
+        prev = dedup.get((lineno, col))
+        if prev == "call_globals" and kind == "assign_to_globals_subscript":
+            dedup[(lineno, col)] = kind
+        elif prev is None:
+            dedup[(lineno, col)] = kind
+    out = [(ln, c, k) for (ln, c), k in sorted(dedup.items())]
+    return out
+
+
+def test_no_globals_injection():
+    offenders = {}
+    for py in dag_files():
+        hits = _detect_globals_injection(py)
+        if hits:
+            offenders[py.name] = hits
+
+    assert not offenders, (
+        "Avoid injecting DAGs with globals(); declare DAGs explicitly instead. Offending locations:\n"
+        + "\n".join(
+            f"  {fname}: "
+            + ", ".join(f"line {ln}:{col} ({kind})" for ln, col, kind in hits)
+            for fname, hits in offenders.items()
+        )
+    )

--- a/tests/test_no_hardcoded_secrets.py
+++ b/tests/test_no_hardcoded_secrets.py
@@ -1,0 +1,140 @@
+# Avoid hardcoded secrets and connection strings in DAG source
+# This test ensures: Credentials stay in Airflow connections, variables, or external secret backends.
+# Guidance: https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/secrets-backend/index.html
+
+import ast
+import re
+
+from conftest import dag_files
+
+_SECRET_NAME_PATTERN = re.compile(
+    r"(password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key|private[_-]?key|client[_-]?secret)",
+    re.IGNORECASE,
+)
+
+_CONNECTION_STRING_PATTERN = re.compile(
+    r"\b(?:postgres(?:ql)?|mysql|mssql|redshift|snowflake|mongodb(?:\+srv)?|redis|amqp|http|https)://[^\s'\"]+:[^\s'\"]+@",
+    re.IGNORECASE,
+)
+
+_SECRET_VALUE_PATTERN = re.compile(
+    r"\b(?:AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|xox[baprs]-[A-Za-z0-9-]{10,}|sk-[A-Za-z0-9]{20,})\b"
+)
+
+_PLACEHOLDER_VALUES = {
+    "",
+    "changeme",
+    "dummy",
+    "example",
+    "fake",
+    "mock",
+    "none",
+    "placeholder",
+    "redacted",
+    "test",
+    "todo",
+}
+
+_SAFE_SECRET_NAME_SUFFIXES = (
+    "_conn_id",
+    "_connection_id",
+    "_variable_key",
+    "_var_key",
+    "_secret_name",
+)
+
+
+def _string_value(node):
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _target_names(target):
+    if isinstance(target, ast.Name):
+        return [target.id]
+    if isinstance(target, ast.Attribute):
+        return [target.attr]
+    if isinstance(target, (ast.Tuple, ast.List)):
+        names = []
+        for element in target.elts:
+            names.extend(_target_names(element))
+        return names
+    return []
+
+
+def _looks_like_secret_name(name: str) -> bool:
+    lowered = name.lower()
+    if lowered.endswith(_SAFE_SECRET_NAME_SUFFIXES):
+        return False
+    return bool(_SECRET_NAME_PATTERN.search(lowered))
+
+
+def _looks_like_secret_value(value: str) -> bool:
+    stripped = value.strip()
+    if stripped.lower() in _PLACEHOLDER_VALUES:
+        return False
+    return bool(
+        _CONNECTION_STRING_PATTERN.search(stripped)
+        or _SECRET_VALUE_PATTERN.search(stripped)
+    )
+
+
+def _is_sensitive_assignment(node):
+    if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+        return []
+
+    value_node = node.value
+    value = _string_value(value_node)
+    if value is None:
+        return []
+
+    targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+    names = [name for target in targets for name in _target_names(target)]
+    violations = []
+
+    for name in names:
+        if (
+            _looks_like_secret_name(name)
+            and value.strip().lower() not in _PLACEHOLDER_VALUES
+        ):
+            violations.append((node.lineno, node.col_offset, f"{name}=<literal>"))
+
+    if _looks_like_secret_value(value):
+        label = names[0] if names else "literal"
+        violations.append(
+            (node.lineno, node.col_offset, f"{label}=<credential-like literal>")
+        )
+
+    return violations
+
+
+def _find_hardcoded_secrets(py_path):
+    text = py_path.read_text(encoding="utf-8", errors="ignore")
+    try:
+        tree = ast.parse(text, filename=str(py_path))
+    except SyntaxError:
+        return []
+
+    violations = []
+    for node in ast.walk(tree):
+        violations.extend(_is_sensitive_assignment(node))
+    return violations
+
+
+def test_no_hardcoded_secrets_in_dags():
+    offenders = {}
+    for py in dag_files():
+        hits = _find_hardcoded_secrets(py)
+        if hits:
+            offenders[py.name] = hits
+
+    assert not offenders, (
+        "Avoid hardcoded secrets or credential-bearing connection strings in DAG source; "
+        "use Airflow connections, variables, or a secrets backend instead. Offending locations:\n"
+        + "\n".join(
+            f"  {fname}: "
+            + ", ".join(f"line {ln}:{col} {desc}" for ln, col, desc in hits)
+            for fname, hits in offenders.items()
+        )
+    )

--- a/tests/test_no_metadata_db_access.py
+++ b/tests/test_no_metadata_db_access.py
@@ -1,0 +1,152 @@
+# Avoid direct Airflow metadata database access from DAG source
+# This test ensures: DAGs do not couple workflow code to Airflow's internal metadata DB schema/session APIs.
+# Guidance: https://airflow.apache.org/docs/apache-airflow/stable/best-practices.html#metadata-db-maintenance
+
+import ast
+
+from conftest import call_name, dag_files
+
+_DISALLOWED_IMPORTS = {
+    "airflow.settings.Session",
+    "airflow.utils.session.create_session",
+    "airflow.utils.session.provide_session",
+}
+
+_SESSION_FACTORY_CALLS = {
+    "airflow.settings.Session",
+    "airflow.utils.session.create_session",
+}
+
+_DISALLOWED_DECORATORS = {
+    "airflow.utils.session.provide_session",
+}
+
+
+def _import_aliases(tree):
+    aliases = {}
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                aliases[alias.asname or alias.name.split(".")[0]] = alias.name
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            for alias in node.names:
+                full_name = f"{node.module}.{alias.name}"
+                aliases[alias.asname or alias.name] = full_name
+    return aliases
+
+
+def _resolve_alias(name: str, aliases: dict[str, str]) -> str:
+    if not name:
+        return name
+
+    first, *rest = name.split(".")
+    if first not in aliases:
+        return name
+    return ".".join([aliases[first], *rest])
+
+
+def _target_names(target):
+    if isinstance(target, ast.Name):
+        return [target.id]
+    if isinstance(target, (ast.Tuple, ast.List)):
+        names = []
+        for element in target.elts:
+            names.extend(_target_names(element))
+        return names
+    return []
+
+
+def _is_session_factory_call(node, aliases) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and _resolve_alias(call_name(node), aliases) in _SESSION_FACTORY_CALLS
+    )
+
+
+def _metadata_session_names(tree, aliases):
+    names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and _is_session_factory_call(
+            node.value, aliases
+        ):
+            for target in node.targets:
+                names.update(_target_names(target))
+
+        if isinstance(node, ast.AnnAssign) and _is_session_factory_call(
+            node.value, aliases
+        ):
+            names.update(_target_names(node.target))
+
+        if isinstance(node, ast.With):
+            for item in node.items:
+                if (
+                    _is_session_factory_call(item.context_expr, aliases)
+                    and item.optional_vars
+                ):
+                    names.update(_target_names(item.optional_vars))
+    return names
+
+
+def _find_metadata_db_access(py_path):
+    text = py_path.read_text(encoding="utf-8", errors="ignore")
+    try:
+        tree = ast.parse(text, filename=str(py_path))
+    except SyntaxError:
+        return []
+
+    aliases = _import_aliases(tree)
+    session_names = _metadata_session_names(tree, aliases)
+    violations = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            for alias in node.names:
+                full_name = f"{node.module}.{alias.name}"
+                if full_name in _DISALLOWED_IMPORTS:
+                    violations.append(
+                        (node.lineno, node.col_offset, f"import {full_name}")
+                    )
+
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for decorator in node.decorator_list:
+                name = (
+                    call_name(decorator)
+                    if isinstance(decorator, ast.Call)
+                    else call_name(ast.Call(func=decorator, args=[], keywords=[]))
+                )
+                resolved = _resolve_alias(name, aliases)
+                if resolved in _DISALLOWED_DECORATORS:
+                    violations.append(
+                        (
+                            decorator.lineno,
+                            decorator.col_offset,
+                            f"decorator {resolved}",
+                        )
+                    )
+
+        if isinstance(node, ast.Call):
+            name = _resolve_alias(call_name(node), aliases)
+            if name in _SESSION_FACTORY_CALLS:
+                violations.append((node.lineno, node.col_offset, f"call {name}"))
+            elif name.endswith(".query") and name.split(".", 1)[0] in session_names:
+                violations.append((node.lineno, node.col_offset, f"call {name}"))
+
+    return violations
+
+
+def test_no_direct_airflow_metadata_db_access():
+    offenders = {}
+    for py in dag_files():
+        hits = _find_metadata_db_access(py)
+        if hits:
+            offenders[py.name] = hits
+
+    assert not offenders, (
+        "Avoid direct Airflow metadata database access from DAG code; use Airflow APIs, context, "
+        "XComs, Variables, Connections, or external application tables instead. Offending locations:\n"
+        + "\n".join(
+            f"  {fname}: "
+            + ", ".join(f"line {ln}:{col} {desc}" for ln, col, desc in hits)
+            for fname, hits in offenders.items()
+        )
+    )

--- a/tests/test_no_nested_loops.py
+++ b/tests/test_no_nested_loops.py
@@ -1,0 +1,182 @@
+# Limit static task creation in loops; prefer dynamic task mapping
+# This test ensures: Loop-generated tasks do not create large static DAGs at parse time.
+# Guidance: https://docs.astronomer.io/learn/dynamic-tasks
+
+import ast
+import os
+
+from conftest import call_name, dag_files
+
+_OPERATOR_HINTS = {"Operator", "Sensor"}
+STATIC_TASK_CREATION_LIMIT = int(os.getenv("AIRFLOW_STATIC_TASK_CREATION_LIMIT", "50"))
+
+
+def _is_task_decorator(decorator) -> bool:
+    if isinstance(decorator, ast.Call):
+        name = call_name(decorator)
+    else:
+        name = call_name(ast.Call(func=decorator, args=[], keywords=[]))
+
+    return name == "task" or name.startswith("task.") or name.endswith(".task")
+
+
+def _taskflow_function_names(tree):
+    names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef):
+            if any(_is_task_decorator(decorator) for decorator in node.decorator_list):
+                names.add(node.name)
+    return names
+
+
+def _looks_like_task_creation(
+    call: ast.Call, taskflow_function_names: set[str]
+) -> bool:
+    name = call_name(call)
+    if not name:
+        return False
+    if any(hint in name for hint in _OPERATOR_HINTS):
+        return True
+    if name in taskflow_function_names:
+        return True
+    return False
+
+
+def _literal_int(node):
+    if isinstance(node, ast.Constant) and isinstance(node.value, int):
+        return node.value
+    return None
+
+
+def _range_length(node: ast.Call):
+    values = [_literal_int(arg) for arg in node.args]
+    if any(value is None for value in values):
+        return None
+
+    try:
+        return len(range(*values))
+    except ValueError:
+        return None
+
+
+def _estimated_iter_count(node, constants):
+    if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+        return len(node.elts)
+    if isinstance(node, ast.Dict):
+        return len(node.keys)
+    if isinstance(node, ast.Name):
+        return constants.get(node.id)
+    if isinstance(node, ast.Call):
+        name = call_name(node)
+        if name == "range":
+            return _range_length(node)
+        if name == "enumerate" and node.args:
+            return _estimated_iter_count(node.args[0], constants)
+        if name == "zip" and node.args:
+            counts = [_estimated_iter_count(arg, constants) for arg in node.args]
+            if all(count is not None for count in counts):
+                return min(counts)
+    return None
+
+
+def _module_iterable_counts(tree):
+    constants = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        if isinstance(target, ast.Name):
+            count = _estimated_iter_count(node.value, constants)
+            if count is not None:
+                constants[target.id] = count
+    return constants
+
+
+class _StaticTaskLoopVisitor(ast.NodeVisitor):
+    def __init__(self, taskflow_function_names: set[str], constants: dict[str, int]):
+        self.taskflow_function_names = taskflow_function_names
+        self.constants = constants
+        self.violations = []
+        self.loop_counts = []
+
+    def visit_FunctionDef(self, node):
+        if any(_is_task_decorator(decorator) for decorator in node.decorator_list):
+            return
+        self.generic_visit(node)
+
+    def visit_AsyncFunctionDef(self, node):
+        if any(_is_task_decorator(decorator) for decorator in node.decorator_list):
+            return
+        self.generic_visit(node)
+
+    def visit_For(self, node: ast.For):
+        self.loop_counts.append(_estimated_iter_count(node.iter, self.constants))
+        self.generic_visit(node)
+        self.loop_counts.pop()
+
+    def visit_While(self, node: ast.While):
+        self.loop_counts.append(None)
+        self.generic_visit(node)
+        self.loop_counts.pop()
+
+    def visit_Call(self, node: ast.Call):
+        name = call_name(node)
+        if self.loop_counts and _looks_like_task_creation(
+            node, self.taskflow_function_names
+        ):
+            if all(count is not None for count in self.loop_counts):
+                estimated_count = 1
+                for count in self.loop_counts:
+                    estimated_count *= count
+                if estimated_count > STATIC_TASK_CREATION_LIMIT:
+                    self.violations.append(
+                        (
+                            node.lineno,
+                            node.col_offset,
+                            name,
+                            f"estimated loop-created tasks={estimated_count}",
+                        )
+                    )
+            elif len(self.loop_counts) >= 2:
+                self.violations.append(
+                    (
+                        node.lineno,
+                        node.col_offset,
+                        name,
+                        "nested dynamic loop-created task count is unknown",
+                    )
+                )
+        self.generic_visit(node)
+
+
+def _find_excessive_static_task_creation(py_path):
+    text = py_path.read_text(encoding="utf-8", errors="ignore")
+    try:
+        tree = ast.parse(text, filename=str(py_path))
+    except Exception:
+        return []
+    visitor = _StaticTaskLoopVisitor(
+        _taskflow_function_names(tree), _module_iterable_counts(tree)
+    )
+    visitor.visit(tree)
+    return visitor.violations
+
+
+def test_static_task_creation_from_loops_is_limited():
+    offenders = {}
+    for py in dag_files():
+        hits = _find_excessive_static_task_creation(py)
+        if hits:
+            offenders[py.name] = hits
+    assert not offenders, (
+        f"Avoid creating more than {STATIC_TASK_CREATION_LIMIT} static tasks from parse-time loops; "
+        "use dynamic task mapping instead. Offending locations:\n"
+        + "\n".join(
+            f"  {fname}: "
+            + ", ".join(
+                f"line {ln}:{col} call={name} ({reason})"
+                for ln, col, name, reason in hits
+            )
+            for fname, hits in offenders.items()
+        )
+    )

--- a/tests/test_no_subdags.py
+++ b/tests/test_no_subdags.py
@@ -1,0 +1,76 @@
+# Avoid SubDAGs; use TaskGroups instead
+# This test ensures: DAGs do not use SubDagOperator or subdag helpers that complicate scheduling.
+# Guidance: https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/dags.html#taskgroups
+
+import ast
+
+from conftest import call_name, dag_files
+
+
+def _import_aliases(tree):
+    aliases = {}
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                aliases[alias.asname or alias.name.split(".")[0]] = alias.name
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            for alias in node.names:
+                aliases[alias.asname or alias.name] = f"{node.module}.{alias.name}"
+    return aliases
+
+
+def _resolve_alias(name: str, aliases: dict[str, str]) -> str:
+    if not name:
+        return name
+
+    first, *rest = name.split(".")
+    if first not in aliases:
+        return name
+    return ".".join([aliases[first], *rest])
+
+
+def _find_subdag_usage(py_path):
+    text = py_path.read_text(encoding="utf-8", errors="ignore")
+    try:
+        tree = ast.parse(text, filename=str(py_path))
+    except SyntaxError:
+        return []
+
+    aliases = _import_aliases(tree)
+    violations = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            names = []
+            if isinstance(node, ast.Import):
+                names = [alias.name for alias in node.names]
+            elif node.module:
+                names = [f"{node.module}.{alias.name}" for alias in node.names]
+
+            for name in names:
+                if "subdag" in name.lower():
+                    violations.append((node.lineno, node.col_offset, f"import {name}"))
+
+        if isinstance(node, ast.Call):
+            name = _resolve_alias(call_name(node), aliases)
+            if name == "SubDagOperator" or name.endswith(".SubDagOperator"):
+                violations.append((node.lineno, node.col_offset, f"call {name}"))
+
+    return violations
+
+
+def test_no_subdags():
+    offenders = {}
+    for py in dag_files():
+        hits = _find_subdag_usage(py)
+        if hits:
+            offenders[py.name] = hits
+
+    assert not offenders, (
+        "Avoid SubDAGs; use TaskGroups or separate DAGs with datasets/assets instead. Offending locations:\n"
+        + "\n".join(
+            f"  {fname}: "
+            + ", ".join(f"line {ln}:{col} {desc}" for ln, col, desc in hits)
+            for fname, hits in offenders.items()
+        )
+    )

--- a/tests/test_no_top_level_execution.py
+++ b/tests/test_no_top_level_execution.py
@@ -1,0 +1,118 @@
+# Avoid code execution at import time
+# This test ensures: Expensive or side-effectful code (print, sleeps, I/O, network) should not run at module import.
+# Guidance: https://airflow.apache.org/docs/apache-airflow/stable/best-practices.html#top-level-python-code
+
+import ast
+
+from conftest import call_name, dag_files
+
+_SIDE_EFFECT_EXACT_CALLS = {
+    "open",
+    "print",
+    "read_csv",
+    "read_json",
+    "read_parquet",
+    "Variable.get",
+    "BaseHook.get_connection",
+}
+
+_SIDE_EFFECT_PREFIXES = (
+    "boto3.",
+    "google.",
+    "httpx.",
+    "os.system",
+    "requests.",
+    "subprocess.",
+)
+
+_SIDE_EFFECT_SUFFIXES = (
+    ".BaseHook.get_connection",
+    ".Variable.get",
+    ".execute",
+    ".get_records",
+    ".read_csv",
+    ".read_json",
+    ".read_parquet",
+    ".run",
+    "sleep",
+)
+
+
+def _import_aliases(tree):
+    aliases = {}
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                aliases[alias.asname or alias.name.split(".")[0]] = alias.name
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            for alias in node.names:
+                aliases[alias.asname or alias.name] = f"{node.module}.{alias.name}"
+    return aliases
+
+
+def _resolve_alias(name: str, aliases: dict[str, str]) -> str:
+    if not name:
+        return name
+
+    first, *rest = name.split(".")
+    if first not in aliases:
+        return name
+    return ".".join([aliases[first], *rest])
+
+
+def _is_side_effect_call(name: str) -> bool:
+    if name in _SIDE_EFFECT_EXACT_CALLS:
+        return True
+    if any(name.startswith(prefix) for prefix in _SIDE_EFFECT_PREFIXES):
+        return True
+    if any(name.endswith(suffix) for suffix in _SIDE_EFFECT_SUFFIXES):
+        return True
+    return False
+
+
+def _find_top_level_side_effects(py_path):
+    text = py_path.read_text(encoding="utf-8", errors="ignore")
+    try:
+        tree = ast.parse(text, filename=str(py_path))
+    except Exception:
+        return []
+    aliases = _import_aliases(tree)
+    violations = []
+
+    class TopLevelSideEffectVisitor(ast.NodeVisitor):
+        def visit_FunctionDef(self, node):
+            return
+
+        def visit_AsyncFunctionDef(self, node):
+            return
+
+        def visit_ClassDef(self, node):
+            return
+
+        def visit_Call(self, node):
+            name = _resolve_alias(call_name(node), aliases)
+            if _is_side_effect_call(name):
+                violations.append((node.lineno, node.col_offset, name))
+            self.generic_visit(node)
+
+    visitor = TopLevelSideEffectVisitor()
+    for statement in tree.body:
+        visitor.visit(statement)
+
+    return violations
+
+
+def test_no_top_level_execution_side_effects():
+    offenders = {}
+    for py in dag_files():
+        hits = _find_top_level_side_effects(py)
+        if hits:
+            offenders[py.name] = hits
+    assert not offenders, (
+        "Avoid side-effectful code at module import time (e.g., print/sleep/I/O/network/subprocess). Offending locations:\n"
+        + "\n".join(
+            f"  {fname}: "
+            + ", ".join(f"line {ln}:{col} call={name}" for ln, col, name in hits)
+            for fname, hits in offenders.items()
+        )
+    )

--- a/tests/test_non_deterministic_dag_ids.py
+++ b/tests/test_non_deterministic_dag_ids.py
@@ -1,0 +1,143 @@
+# Prevent random/time-based DAG IDs
+# This test ensures: Random or time-based DAG IDs prevent consistent history and break backfills.
+# Guidance: https://docs.astronomer.io/learn/dynamically-generating-dags
+
+import ast
+
+from conftest import call_name, dag_files
+
+# Calls that produce non-deterministic values
+_NONDETERMINISTIC_CALLS = {
+    "uuid.uuid1",
+    "uuid.uuid4",
+    "random.random",
+    "random.randint",
+    "random.choice",
+    "random.uniform",
+    "random.sample",
+    "random.randrange",
+    "datetime.now",
+    "datetime.utcnow",
+    "datetime.datetime.now",
+    "datetime.datetime.utcnow",
+    "datetime.date.today",
+    "date.today",
+    "pendulum.now",
+    "pendulum.today",
+    "time.time",
+    "time.time_ns",
+}
+
+_NONDETERMINISTIC_PREFIXES = ("random.",)
+
+
+def _import_aliases(tree):
+    aliases = {}
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                aliases[alias.asname or alias.name.split(".")[0]] = alias.name
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            for alias in node.names:
+                aliases[alias.asname or alias.name] = f"{node.module}.{alias.name}"
+    return aliases
+
+
+def _resolve_alias(name: str, aliases: dict[str, str]) -> str:
+    if not name:
+        return name
+
+    first, *rest = name.split(".")
+    if first not in aliases:
+        return name
+    return ".".join([aliases[first], *rest])
+
+
+def _contains_nondeterministic_call(node, aliases):
+    """Walk an AST subtree and return True if it contains a non-deterministic call."""
+    for child in ast.walk(node):
+        if isinstance(child, ast.Call):
+            name = _resolve_alias(call_name(child), aliases)
+            if name in _NONDETERMINISTIC_CALLS:
+                return True
+            if any(name.startswith(p) for p in _NONDETERMINISTIC_PREFIXES):
+                return True
+    return False
+
+
+def _find_dynamic_dag_id(py_path):
+    text = py_path.read_text(encoding="utf-8", errors="ignore")
+    try:
+        tree = ast.parse(text, filename=str(py_path))
+    except Exception:
+        return []
+
+    aliases = _import_aliases(tree)
+
+    # Build a map of variable name -> assignment value node for simple tracing
+    var_assignments = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            tgt = node.targets[0]
+            if isinstance(tgt, ast.Name):
+                var_assignments[tgt.id] = node.value
+
+    violations = []
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.keyword) and node.arg == "dag_id"):
+            continue
+        val = node.value
+
+        # Direct non-deterministic call: dag_id=uuid.uuid4()
+        if isinstance(val, ast.Call):
+            name = _resolve_alias(call_name(val), aliases)
+            if name in _NONDETERMINISTIC_CALLS or any(
+                name.startswith(p) for p in _NONDETERMINISTIC_PREFIXES
+            ):
+                violations.append(
+                    (node.lineno, node.col_offset, f"dag_id from call {name}")
+                )
+            continue
+
+        # f-string or concatenation — only flag if the subtree contains a bad call
+        if isinstance(val, (ast.JoinedStr, ast.BinOp)):
+            if _contains_nondeterministic_call(val, aliases):
+                violations.append(
+                    (
+                        node.lineno,
+                        node.col_offset,
+                        "dag_id built with non-deterministic expression",
+                    )
+                )
+            continue
+
+        # Variable reference: dag_id=some_var — trace one level
+        if isinstance(val, ast.Name) and val.id in var_assignments:
+            assigned = var_assignments[val.id]
+            if _contains_nondeterministic_call(assigned, aliases):
+                violations.append(
+                    (
+                        node.lineno,
+                        node.col_offset,
+                        f"dag_id from variable '{val.id}' containing non-deterministic call",
+                    )
+                )
+            continue
+
+    return violations
+
+
+def test_non_deterministic_dag_ids():
+    offenders = {}
+    for py in dag_files():
+        hits = _find_dynamic_dag_id(py)
+        if hits:
+            offenders[py.name] = hits
+    assert not offenders, (
+        "DAG IDs must be static and deterministic (avoid uuid/random/time-based). Offending locations:\n"
+        + "\n".join(
+            f"  {fname}: "
+            + ", ".join(f"line {ln}:{col} {desc}" for ln, col, desc in hits)
+            for fname, hits in offenders.items()
+        )
+    )

--- a/tests/test_sensor_modes.py
+++ b/tests/test_sensor_modes.py
@@ -1,0 +1,85 @@
+# Avoid long-running sensors in poke mode
+# This test ensures: Sensors that wait for minutes or hours release worker slots while waiting.
+# Guidance: https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/sensors.html
+
+import ast
+import os
+
+from conftest import call_name, dag_files
+
+LONG_POKE_INTERVAL_SECONDS = int(
+    os.getenv("AIRFLOW_LONG_SENSOR_POKE_INTERVAL_SECONDS", "300")
+)
+LONG_TIMEOUT_SECONDS = int(os.getenv("AIRFLOW_LONG_SENSOR_TIMEOUT_SECONDS", "1800"))
+
+
+def _literal_value(node):
+    if isinstance(node, ast.Constant):
+        return node.value
+    return None
+
+
+def _keyword_value(call: ast.Call, keyword_name: str):
+    for keyword in call.keywords:
+        if keyword.arg == keyword_name:
+            return _literal_value(keyword.value)
+    return None
+
+
+def _is_sensor_call(call: ast.Call) -> bool:
+    name = call_name(call)
+    return name == "Sensor" or name.endswith("Sensor")
+
+
+def _is_long_wait_sensor(call: ast.Call) -> bool:
+    poke_interval = _keyword_value(call, "poke_interval")
+    timeout = _keyword_value(call, "timeout")
+
+    if (
+        isinstance(poke_interval, (int, float))
+        and poke_interval >= LONG_POKE_INTERVAL_SECONDS
+    ):
+        return True
+    if isinstance(timeout, (int, float)) and timeout >= LONG_TIMEOUT_SECONDS:
+        return True
+    return False
+
+
+def _uses_reschedule_or_deferrable(call: ast.Call) -> bool:
+    mode = _keyword_value(call, "mode")
+    deferrable = _keyword_value(call, "deferrable")
+
+    return mode == "reschedule" or deferrable is True
+
+
+def _find_long_poke_mode_sensors(py_path):
+    text = py_path.read_text(encoding="utf-8", errors="ignore")
+    try:
+        tree = ast.parse(text, filename=str(py_path))
+    except SyntaxError:
+        return []
+
+    violations = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and _is_sensor_call(node):
+            if _is_long_wait_sensor(node) and not _uses_reschedule_or_deferrable(node):
+                violations.append((node.lineno, node.col_offset, call_name(node)))
+    return violations
+
+
+def test_long_running_sensors_release_worker_slots():
+    offenders = {}
+    for py in dag_files():
+        hits = _find_long_poke_mode_sensors(py)
+        if hits:
+            offenders[py.name] = hits
+
+    assert not offenders, (
+        "Long-running sensors should use `mode='reschedule'` or `deferrable=True` "
+        "so they do not hold worker slots while waiting. Offending locations:\n"
+        + "\n".join(
+            f"  {fname}: "
+            + ", ".join(f"line {ln}:{col} call={name}" for ln, col, name in hits)
+            for fname, hits in offenders.items()
+        )
+    )

--- a/tests/test_static_start_date.py
+++ b/tests/test_static_start_date.py
@@ -1,0 +1,138 @@
+# Avoid dynamic start_date values in DAG definitions
+# This test ensures: DAG schedules are based on stable, deterministic start dates.
+# Guidance: https://airflow.apache.org/docs/apache-airflow/stable/best-practices.html#top-level-python-code
+
+import ast
+
+from conftest import call_name, dag_files
+
+_DYNAMIC_DATE_CALLS = {
+    "date.today",
+    "datetime.date.today",
+    "datetime.datetime.now",
+    "datetime.datetime.today",
+    "datetime.datetime.utcnow",
+    "datetime.now",
+    "datetime.today",
+    "datetime.utcnow",
+    "pendulum.now",
+    "pendulum.today",
+    "timezone.utcnow",
+    "airflow.utils.dates.days_ago",
+    "days_ago",
+}
+
+
+def _import_aliases(tree):
+    aliases = {}
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                aliases[alias.asname or alias.name.split(".")[0]] = alias.name
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            for alias in node.names:
+                aliases[alias.asname or alias.name] = f"{node.module}.{alias.name}"
+    return aliases
+
+
+def _resolve_alias(name: str, aliases: dict[str, str]) -> str:
+    if not name:
+        return name
+
+    first, *rest = name.split(".")
+    if first not in aliases:
+        return name
+    return ".".join([aliases[first], *rest])
+
+
+def _string_key(node):
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _contains_dynamic_date_call(node, aliases) -> bool:
+    for child in ast.walk(node):
+        if isinstance(child, ast.Call):
+            name = _resolve_alias(call_name(child), aliases)
+            if name in _DYNAMIC_DATE_CALLS:
+                return True
+    return False
+
+
+def _dict_has_dynamic_start_date(node, aliases) -> bool:
+    if not isinstance(node, ast.Dict):
+        return False
+
+    for key, value in zip(node.keys, node.values):
+        if _string_key(key) == "start_date" and _contains_dynamic_date_call(
+            value, aliases
+        ):
+            return True
+    return False
+
+
+def _module_dict_assignments(tree):
+    assignments = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        if isinstance(target, ast.Name) and isinstance(node.value, ast.Dict):
+            assignments[target.id] = node.value
+    return assignments
+
+
+def _find_dynamic_start_dates(py_path):
+    text = py_path.read_text(encoding="utf-8", errors="ignore")
+    try:
+        tree = ast.parse(text, filename=str(py_path))
+    except SyntaxError:
+        return []
+
+    aliases = _import_aliases(tree)
+    dict_assignments = _module_dict_assignments(tree)
+    violations = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.keyword) and node.arg == "start_date":
+            if _contains_dynamic_date_call(node.value, aliases):
+                violations.append(
+                    (node.lineno, node.col_offset, "dynamic start_date keyword")
+                )
+
+        if isinstance(node, ast.keyword) and node.arg == "default_args":
+            if _dict_has_dynamic_start_date(node.value, aliases):
+                violations.append(
+                    (node.lineno, node.col_offset, "dynamic start_date in default_args")
+                )
+            elif isinstance(node.value, ast.Name):
+                default_args = dict_assignments.get(node.value.id)
+                if default_args and _dict_has_dynamic_start_date(default_args, aliases):
+                    violations.append(
+                        (
+                            node.lineno,
+                            node.col_offset,
+                            f"dynamic start_date in default_args variable '{node.value.id}'",
+                        )
+                    )
+
+    return violations
+
+
+def test_start_date_is_static():
+    offenders = {}
+    for py in dag_files():
+        hits = _find_dynamic_start_dates(py)
+        if hits:
+            offenders[py.name] = hits
+
+    assert not offenders, (
+        "DAG start_date values must be static and deterministic; avoid datetime.now(), "
+        "pendulum.now(), days_ago(), and similar moving dates. Offending locations:\n"
+        + "\n".join(
+            f"  {fname}: "
+            + ", ".join(f"line {ln}:{col} {desc}" for ln, col, desc in hits)
+            for fname, hits in offenders.items()
+        )
+    )


### PR DESCRIPTION
## Summary

Adds a GitHub Actions CI pipeline for the Civic Data Warehouse and brings the codebase into compliance so the first run is green. **Checks only — no deploy yet** (a gated Astro Cloud deploy can be added later behind secrets).

## CI (`.github/workflows/ci.yml`)
Runs on every PR and on pushes to `master`:

| Job | Purpose |
|---|---|
| **Lint (ruff)** | `ruff check` + `ruff format --check` on `dags/`, `include/`, `tests/` |
| **Static DAG policy tests** | Pure-AST best-practice checks (no Airflow) — fast PR feedback |
| **DAG integrity tests (Astro Runtime)** | Builds the project image (validates the Docker build) and runs the full `pytest` suite inside it (import errors, tags, `retries >= 2`, `catchup=False`, DagBag best-practice checks) |

DAG tests are adapted from Astronomer's [best_practices_pytests](https://github.com/astronomer/best_practices_pytests).

## Supporting config
- `pyproject.toml` — ruff (`E,F,I,W`; `E501` left to the formatter) + pytest config
- `requirements-dev.txt` — `pytest`, `ruff` (CI/dev only; not in the runtime image)
- `tests/` — vendored best-practice tests + `conftest.py` (intentionally-broken `bad_*.py` fixtures were not copied)

## Compliance changes (to make CI green)
- All DAGs now set `tags`, `catchup=False`, and `retries >= 2`
- Lint fixes (import order, `except:` → `except Exception:`, dead assignments, redundant f-strings) and `ruff format` applied across `dags/` and `include/`. The large `include/process_parcel_data.py` / `include/check_urls.py` diffs are almost entirely one-time formatting.

## Validation
Full suite verified locally inside the Astro Runtime 3.1-13 image: **28 passed, 2 skipped** (the 2 skips are opt-in profiling tests). `ruff check` and `ruff format --check` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)