### PR TITLE
Transformation foundation: CDW_ID standard + current DDL (Wave 1) and staging decode fix (Wave 0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ CDW PostgreSQL (Data Warehouse)
 A dedicated Postgres 15 instance that serves as the **data warehouse** itself. This is separate from Airflow's internal metadata database. It contains three schemas:
 
 - **`staging`** — raw data loaded directly from S3 CSVs
+- **`crosswalk`** — persistent CDW_ID registries such as parcel handle → parcel sequence mappings
 - **`current`** — normalized tables (parcel, building, unit, address, legal_entity, etc.)
 - **`history`** — historical snapshots of the current schema
 
@@ -74,9 +75,9 @@ All DAGs are manually triggered (`schedule=None`) unless noted otherwise. They s
 
 **File:** `dags/create_cdw_databases.py`
 
-Creates the three CDW schemas (`staging`, `current`, `history`) and a utility function for truncating tables. Run this once before any other DAG.
+Creates the CDW schemas (`staging`, `crosswalk`, `current`, `history`) and a utility function for truncating tables. Run this once before any other DAG. The `crosswalk` schema is persistent ID registry state and should not be truncated during normal rebuilds.
 
-**Task order:** `create_staging` > `create_data_prep` > `create_history` > `create_truncate_tables_function`
+**Task order:** `create_staging` > `create_crosswalk` > `create_data_prep` > `create_history` > `create_truncate_tables_function`
 
 ### 2. `govt_file_download` — Data Ingestion
 
@@ -109,7 +110,7 @@ Truncates the `staging` schema, lists all files in the S3 landing zone, then dyn
 
 | DAG | File | Purpose |
 |-----|------|---------|
-| `sql_test` | `dags/sql_test.py` | Connectivity check — verifies the `staging`, `current`, and `history` schemas exist in the CDW database. |
+| `sql_test` | `dags/sql_test.py` | Connectivity check — verifies the `staging`, `crosswalk`, `current`, and `history` schemas exist in the CDW database. |
 | `example_secrets_dag` | `dags/secret_manager_test.py` | Tests secrets backend integration by retrieving an Airflow Variable and the `cdw-dev` connection. |
 | `survey_dag_parsing_times` | `dags/dag_parsing_survey.py` | Profiles DAG parse times. **Only DAG with a schedule** (daily). |
 

--- a/dags/create_cdw_databases.py
+++ b/dags/create_cdw_databases.py
@@ -24,6 +24,13 @@ with DAG(
         sql="create_staging.sql",
     )
 
+    # Create schema "crosswalk" in cdw database
+    create_crosswalk = SQLExecuteQueryOperator(
+        task_id="create_crosswalk",
+        conn_id="cdw-dev",
+        sql="create_crosswalk.sql",
+    )
+
     # Create schema "current" in cdw database
     create_current = SQLExecuteQueryOperator(
         task_id="create_data_prep",
@@ -43,4 +50,10 @@ with DAG(
         conn_id="cdw-dev",
         sql="create_truncate_tables_function.sql",
     )
-create_staging >> create_current >> create_history >> create_truncate_tables_function
+(
+    create_staging
+    >> create_crosswalk
+    >> create_current
+    >> create_history
+    >> create_truncate_tables_function
+)

--- a/dags/sql_test.py
+++ b/dags/sql_test.py
@@ -15,5 +15,5 @@ with DAG(
     truncate_staging = SQLExecuteQueryOperator(
         task_id="sql_test",
         conn_id="cdw-dev",
-        sql="SELECT schema_name FROM information_schema.schemata WHERE schema_name IN ('staging', 'current', 'history')",
+        sql="SELECT schema_name FROM information_schema.schemata WHERE schema_name IN ('staging', 'crosswalk', 'current', 'history')",
     )

--- a/documentation/pipeline_architecture/staging_to_current.md
+++ b/documentation/pipeline_architecture/staging_to_current.md
@@ -83,6 +83,8 @@ Identity & crosswalk
 - Parcel `cdw_id` = `840.29510.<parcel_seq>.0000.00000`, where `parcel_seq` is minted from `handle`
   via `crosswalk.parcel_xref` (the authoritative per-region registry). `handle` is preserved in
   `current.municipal_parcel_id_mapping`.
+- `crosswalk.parcel_xref` is persistent pipeline state. It survives current-schema rebuilds so an
+  existing native `handle` keeps the same `parcel_seq` on every run.
 - Building = `…<bldgnum:4>.00000`; unit = `…<bldgnum:4>.<unitseq:5>`. Condo buildings synthesize
   `…0001.00000`; condo units order deterministically by assessor parcel number.
 - Non-spine surrogates are namespaced TEXT (`840.29510.<entity>.<seq>`). See

--- a/documentation/schema/cdw_id.md
+++ b/documentation/schema/cdw_id.md
@@ -35,7 +35,7 @@ Structure
 =========
 ```
 <country>.<region>.<parcel>.<building>.<unit>
-   840   . 29510  .  000123  .  0000   . 00000      ← a St. Louis City parcel
+   840   . 29510  . 00012345 .  0000   . 00000      ← a St. Louis City parcel
 ```
 
 | Segment   | Authority (guarantees uniqueness)                                              | Notes |
@@ -46,7 +46,12 @@ Structure
 | building  | Sequence within the parcel                                                     | `0000` = parcel-level record (no building) |
 | unit      | Sequence within the building                                                   | `00000` = building-level record (no unit) |
 
-Any level not applicable is zero-filled (a vacant lot = `840.29510.000123.0000.00000`), and the
+**Canonical field widths** (zero-padded, used by the generated `cdw_id`): country **3**, region
+**5**, parcel **8**, building **4**, unit **5** — e.g. `840.29510.00012345.0007.00042`. (Country =
+ISO 3166-1 numeric is exactly 3; region = US FIPS is exactly 5; these widths are fixed so ids sort
+and prefix-join correctly.)
+
+Any level not applicable is zero-filled (a vacant lot = `840.29510.00012345.0000.00000`), and the
 identifier still joins cleanly by prefix — e.g. all parcels in a region are
 `840.29510.%`, all units of a building share its `…<parcel>.<building>.%` prefix.
 

--- a/documentation/schema/cdw_id.md
+++ b/documentation/schema/cdw_id.md
@@ -79,6 +79,11 @@ The crosswalk (`crosswalk.parcel_xref`: region, native reference `UNIQUE`, parce
 regenerated. Sequences are collision-free within a region; the one disallowed situation is two
 independent crosswalks minting the same region.
 
+Operationally, `include/sql/create_crosswalk.sql` creates this registry. New rows in
+`crosswalk.parcel_xref` may omit `parcel_seq`; a trigger allocates the next value from the
+region-specific Postgres sequence. Pipeline rebuilds should read and append to this table, not
+truncate it.
+
 Storage
 =======
 A full CDW_ID is far wider than a 64-bit integer, so it is stored as **TEXT**, not a number.

--- a/documentation/schema/schema.dbml
+++ b/documentation/schema/schema.dbml
@@ -1,31 +1,54 @@
-// Entities
+// =============================================================================
+// CDW "current" schema
+// -----------------------------------------------------------------------------
+// Spine tables (parcel, building, unit) carry the CDW_ID as component columns
+// plus a generated STORED text column `cdw_id` that is the zero-padded,
+// dot-delimited concatenation and serves as the TEXT primary key:
+//     CCCC.cccccc.pppppppp.bbbb.uuuuu
+// Lower levels are zero-filled (parcel -> ....0000.00000, building -> ....00000).
+// All non-spine tables use namespaced TEXT surrogate keys (<country>.<region>.<entity>.<seq>).
+// =============================================================================
+
+// Spine
 Table parcel [headercolor: #3498db] {
-  parcel_id int [pk, note: 'REDB identifier, not municapal identifier (handle)']
-  county_id int [ref: > county.county_id]
-  owner_id int [ref: > legal_entity.legal_entity_id]
-  ward_id int [ref: > ward.ward_id]
-  neighborhood_id int [ref: > neighborhood.neighborhood_id]
-  zip_code varchar
-  census_block int
+  country_code text [not null]
+  region_code text [not null]
+  parcel_seq bigint [not null]
+  cdw_id text [pk, note: 'GENERATED STORED: CCCC.cccccc.pppppppp.0000.00000']
+  county varchar
+  owner_id text [ref: > legal_entity.legal_entity_id]
+  ward int
+  neighborhood varchar
+  zip_code text
+  census_block text
   frontage int
-  zoning_class_id int [ref: > zoning_class.zoning_class_id]
+  zoning_class_id text [ref: > zoning_class.zoning_class_id]
 }
 
 Table building [headercolor: #3498db] {
-  building_id int [pk]
-  parcel_id int [ref: > parcel.parcel_id]
-  owner_id int [ref: > legal_entity.legal_entity_id]
-  use_type_id int [ref: > use_type.use_type_id]
+  country_code text [not null]
+  region_code text [not null]
+  parcel_seq bigint [not null]
+  building_seq bigint [not null]
+  cdw_id text [pk, note: 'GENERATED STORED: CCCC.cccccc.pppppppp.bbbb.00000']
+  parcel_cdw_id text [not null, ref: > parcel.cdw_id]
+  owner_id text [ref: > legal_entity.legal_entity_id]
+  use_type_id text [ref: > use_type.use_type_id]
   sq_footage int
   year_built int
 }
 
 Table unit [headercolor: #3498db] {
-  unit_id int  [pk]
-  building_id int [ref: > building.building_id]
-  owner_id int [ref: > legal_entity.legal_entity_id]
-  use_type_id int [ref: > use_type.use_type_id]
-  address_id int [ref: > address.address_id]
+  country_code text [not null]
+  region_code text [not null]
+  parcel_seq bigint [not null]
+  building_seq bigint [not null]
+  unit_seq bigint [not null]
+  cdw_id text [pk, note: 'GENERATED STORED: CCCC.cccccc.pppppppp.bbbb.uuuuu']
+  building_cdw_id text [not null, ref: > building.cdw_id]
+  owner_id text [ref: > legal_entity.legal_entity_id]
+  use_type_id text [ref: > use_type.use_type_id]
+  address_id text [ref: > address.address_id]
   ground_floor bool
   stories float
   windows_ac int
@@ -35,73 +58,72 @@ Table unit [headercolor: #3498db] {
   garage int
 }
 
+// Shared entities
 Table legal_entity [headercolor: #3498db] {
-  legal_entity_id int [pk]
+  legal_entity_id text [pk]
   name varchar
-  address_id int [ref: > address.address_id]
+  address_id text [ref: > address.address_id]
 }
 
 Table address [headercolor: #3498db] {
-  address_id int [pk]
-  street_number varchar
+  address_id text [pk]
+  raw_line text [note: 'un-componentized source address line, verbatim']
+  street_number int
   street_name_prefix varchar
   street_name varchar
   street_name_suffix varchar
   secondary_designator varchar
   city varchar
   state varchar
-  zip varchar
+  zip text
 }
 
 // Operations
 Table permit [headercolor: #e67e22] {
-  permit_id int  [pk]
-  parcel_id int [ref: > parcel.parcel_id]
-  building_id int [ref: > building.building_id]
-  unit_id int [ref: > unit.unit_id]
-  permit_type_id int [ref: > permit_type.permit_type_id]
+  permit_id text [pk]
+  permit_type_id text [ref: > permit_type.permit_type_id]
   application_date date
   issue_date date
   completion_date date
   cancel_date date
   description varchar
   cost float
-  applicant_id int [ref: - legal_entity.legal_entity_id]
-  contractor_id int [ref: - legal_entity.legal_entity_id]
+  applicant_id text [ref: - legal_entity.legal_entity_id]
+  contractor_id text [ref: - legal_entity.legal_entity_id]
 }
 
 Table service [headercolor: #e67e22] {
-  service_id int [pk]
-  parcel_id int [ref: > parcel.parcel_id]
-  building_id int [ref: > building.building_id]
-  unit_id int [ref: > unit.unit_id]
-  owner_id int [ref: > legal_entity.legal_entity_id]
-  division_id int [ref: > division.division_id]
+  service_id text [pk]
+  parcel_id text [ref: > parcel.cdw_id]
+  building_id text [ref: > building.cdw_id]
+  unit_id text [ref: > unit.cdw_id]
+  owner_id text [ref: > legal_entity.legal_entity_id]
+  division_id text [ref: > division.division_id]
   service_date date
-  service_type_id int [ref: > service_type.service_type_id]
+  service_type_id text [ref: > service_type.service_type_id]
   fee float8
 }
 
 Table condemnation [headercolor: #e67e22] {
-  condemnation_id int [pk]
-  inspection_id int [ref: > inspection.inspection_id]
+  condemnation_id text [pk]
+  inspection_id text [ref: > inspection.inspection_id]
   letter_date date
-  condemnation_type_id int [ref: > condemnation_type.condemnation_type_id]
-  condemnation_status_id int [ref: > condemnation_status.condemnation_status_id]
+  condemnation_type varchar
+  status varchar
 }
 
 Table inspection [headercolor: #e67e22] {
-  inspection_id int [pk]
-  building_id int [ref: > building.building_id]
+  inspection_id text [pk]
+  building_id text [ref: > building.cdw_id]
   inspection_date date
   completion_date date
-  inspection_type_id int [ref: > inspection_type.inspection_type_id]
+  inspection_type_id text [ref: > inspection_type.inspection_type_id]
   number_of_violations int
 }
 
 Table assessment [headercolor: #e67e22] {
-  assessment_id int [pk]
-  parcel_id int [ref: > parcel.parcel_id]
+  assessment_id text [pk]
+  parcel_id text [ref: > parcel.cdw_id]
   assessment_date date
   assessment_amount float
   land_value float
@@ -109,97 +131,68 @@ Table assessment [headercolor: #e67e22] {
 }
 
 Table tax_delinquency [headercolor: #e67e22] {
-  tax_delinquency_id int [pk]
-  parcel_id int [ref: > parcel.parcel_id]
-  legal_entity_id int [ref: > legal_entity.legal_entity_id]
+  tax_delinquency_id text [pk]
+  legal_entity_id text [ref: > legal_entity.legal_entity_id]
   last_paid_year int
   amount_delinquent float
 }
 
-Table sale [headercolor: #e67e22] {
-  sale_id int [pk]
-  parcel_id int [ref: > parcel.parcel_id]
-  sale_date date
-  sale_price float
-  buyer_id int [ref: > legal_entity.legal_entity_id]
-  seller_id int [ref: > legal_entity.legal_entity_id]
-  instrument_type varchar
-  deed_book varchar
-  deed_page varchar
-}
-
-Table violation [headercolor: #e67e22] {
-  violation_id int [pk]
-  inspection_id int [ref: > inspection.inspection_id]
-  code_cited varchar
-  severity varchar
-  status varchar
-  compliance_date date
-}
-
 // Lookups
-Table county [headercolor: #9b59b6] {
-  county_id int [pk]
-  county varchar
-}
-
-Table ward [headercolor: #9b59b6] {
-  ward_id int [pk]
-  ward int
-}
-
-Table neighborhood [headercolor: #9b59b6] {
-  neighborhood_id int [pk]
-  neighborhood varchar
-}
-
 Table municipality [headercolor: #9b59b6] {
-  municipality_id int [pk]
+  municipality_id text [pk]
   municipality varchar
 }
 
 Table division [headercolor: #9b59b6] {
-  division_id int [pk]
+  division_id text [pk]
   division varchar
 }
 
 Table service_type [headercolor: #9b59b6] {
-  service_type_id int [pk]
+  service_type_id text [pk]
   service_type varchar
 }
 
 Table zoning_class [headercolor: #9b59b6] {
-  zoning_class_id int [pk]
+  zoning_class_id text [pk]
   zoning_class varchar
 }
 
 Table municipal_parcel_id_mapping [headercolor: #9b59b6] {
-  parcel_id int [pk, ref: > parcel.parcel_id]
-  municpal_parcel_id varchar
-  municipality_id int [ref: > municipality.municipality_id]
+  parcel_id text [pk, ref: > parcel.cdw_id]
+  municipal_parcel_id varchar [note: 'city native parcel reference (assessor handle)']
+  municipality_id text [ref: > municipality.municipality_id]
 }
 
 Table use_type [headercolor: #9b59b6] {
-  use_type_id int [pk]
-  use_type varchar
+  use_type_id text [pk]
+  use_type text
 }
 
 Table permit_type [headercolor: #9b59b6] {
-  permit_type_id int [pk]
+  permit_type_id text [pk]
   permit_type varchar
 }
 
 Table inspection_type [headercolor: #9b59b6] {
-  inspection_type_id int [pk]
+  inspection_type_id text [pk]
   inspection_type varchar
 }
 
-Table condemnation_type [headercolor: #9b59b6] {
-  condemnation_type_id int [pk]
-  condemnation_type varchar
+// Capture tables
+Table exclusion_log [headercolor: #95a5a6] {
+  exclusion_id text [pk]
+  source_table varchar
+  source_natural_key varchar
+  reason varchar
+  raw_payload jsonb
+  excluded_at timestamptz
 }
 
-Table condemnation_status [headercolor: #9b59b6] {
-  condemnation_status_id int [pk]
-  condemnation_status varchar
+Table secondary_owner [headercolor: #95a5a6] {
+  secondary_owner_id text [pk]
+  parcel_id text [not null, ref: > parcel.cdw_id]
+  owner_id text [not null, ref: > legal_entity.legal_entity_id]
+  ownership_role varchar
+  ownership_share numeric
 }

--- a/include/sql/create_crosswalk.sql
+++ b/include/sql/create_crosswalk.sql
@@ -1,0 +1,112 @@
+-- =============================================================================
+-- CDW "crosswalk" schema DDL
+-- -----------------------------------------------------------------------------
+-- Persistent ID registries used while transforming source records into the CDW
+-- spine. Crosswalk tables are authoritative state: they are not staging output
+-- and must not be truncated or regenerated during normal pipeline rebuilds.
+-- =============================================================================
+
+CREATE SCHEMA IF NOT EXISTS crosswalk;
+
+CREATE TABLE IF NOT EXISTS crosswalk.parcel_xref (
+  region_code text NOT NULL,
+  native_ref text NOT NULL,
+  parcel_seq bigint NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT parcel_xref_pkey PRIMARY KEY (region_code, native_ref),
+  CONSTRAINT parcel_xref_region_seq_key UNIQUE (region_code, parcel_seq),
+  CONSTRAINT parcel_xref_region_code_not_blank CHECK (btrim(region_code) <> ''),
+  CONSTRAINT parcel_xref_native_ref_not_blank CHECK (btrim(native_ref) <> ''),
+  CONSTRAINT parcel_xref_parcel_seq_positive CHECK (parcel_seq > 0)
+);
+
+COMMENT ON SCHEMA crosswalk IS
+  'Persistent CDW_ID crosswalks. Authoritative ID registry; do not truncate or regenerate.';
+
+COMMENT ON TABLE crosswalk.parcel_xref IS
+  'Authoritative mapping from a region-native parcel reference to the stable CDW parcel sequence.';
+
+COMMENT ON COLUMN crosswalk.parcel_xref.region_code IS
+  'Parcel-issuing jurisdiction namespace, e.g. St. Louis City FIPS 29510.';
+
+COMMENT ON COLUMN crosswalk.parcel_xref.native_ref IS
+  'Native parcel reference from the source system, e.g. the St. Louis assessor handle.';
+
+COMMENT ON COLUMN crosswalk.parcel_xref.parcel_seq IS
+  'CDW-minted parcel localId. Unique within region_code and never reassigned.';
+
+CREATE OR REPLACE FUNCTION crosswalk.parcel_seq_sequence_name(region_code text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT 'parcel_seq_' || regexp_replace(btrim(region_code), '[^A-Za-z0-9_]+', '_', 'g');
+$$;
+
+COMMENT ON FUNCTION crosswalk.parcel_seq_sequence_name(text) IS
+  'Returns the per-region sequence name used to allocate parcel_xref.parcel_seq values.';
+
+CREATE OR REPLACE FUNCTION crosswalk.next_parcel_seq(region_code text)
+RETURNS bigint
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  normalized_region text := btrim(region_code);
+  sequence_name text;
+BEGIN
+  IF normalized_region IS NULL OR normalized_region = '' THEN
+    RAISE EXCEPTION 'region_code is required to allocate a parcel sequence';
+  END IF;
+
+  sequence_name := crosswalk.parcel_seq_sequence_name(normalized_region);
+
+  IF to_regclass(format('%I.%I', 'crosswalk', sequence_name)) IS NULL THEN
+    EXECUTE format(
+      'CREATE SEQUENCE IF NOT EXISTS %I.%I AS bigint START WITH 1 INCREMENT BY 1 NO MINVALUE NO MAXVALUE CACHE 1',
+      'crosswalk',
+      sequence_name
+    );
+  END IF;
+
+  RETURN nextval(format('%I.%I', 'crosswalk', sequence_name)::regclass);
+END;
+$$;
+
+COMMENT ON FUNCTION crosswalk.next_parcel_seq(text) IS
+  'Allocates the next parcel sequence from the sequence dedicated to the given region_code.';
+
+CREATE OR REPLACE FUNCTION crosswalk.set_parcel_xref_defaults()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.region_code := btrim(NEW.region_code);
+  NEW.updated_at := now();
+
+  IF NEW.parcel_seq IS NULL THEN
+    NEW.parcel_seq := crosswalk.next_parcel_seq(NEW.region_code);
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION crosswalk.set_parcel_xref_defaults() IS
+  'Assigns parcel_seq from the region-specific sequence when a parcel_xref row omits it.';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgname = 'parcel_xref_set_defaults'
+      AND tgrelid = 'crosswalk.parcel_xref'::regclass
+  ) THEN
+    CREATE TRIGGER parcel_xref_set_defaults
+    BEFORE INSERT OR UPDATE ON crosswalk.parcel_xref
+    FOR EACH ROW
+    EXECUTE FUNCTION crosswalk.set_parcel_xref_defaults();
+  END IF;
+END;
+$$;

--- a/include/sql/create_current.sql
+++ b/include/sql/create_current.sql
@@ -1,32 +1,150 @@
+-- =============================================================================
+-- CDW "current" schema DDL
+-- -----------------------------------------------------------------------------
+-- Implements the CDW_ID standard (documentation/schema/cdw_id.md):
+--
+--     CCCC.cccccc.pppppppp.bbbb.uuuuu
+--     country(4) . region/county(6) . parcel(8) . building(4) . unit(5)
+--
+-- Spine tables (parcel, building, unit) store the CDW_ID as component columns
+-- plus a generated STORED text column `cdw_id` that is the zero-padded,
+-- dot-delimited concatenation. `cdw_id` is the TEXT PRIMARY KEY. Lower levels
+-- not applicable to a given spine row are zero-filled:
+--     parcel    -> ....pppppppp.0000.00000
+--     building  -> ....pppppppp.bbbb.00000
+--     unit      -> ....pppppppp.bbbb.uuuuu
+--
+-- Non-spine tables use namespaced TEXT surrogate primary keys of the form
+--     <country>.<region>.<entity>.<seq>
+-- All foreign keys are TEXT to match the keys they reference.
+-- =============================================================================
+
 CREATE SCHEMA IF NOT EXISTS current ;
 
+-- =============================================================================
+-- Lookup tables (namespaced TEXT surrogate keys)
+-- These are created first so spine/operations FKs can reference them.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS "cdw"."current"."municipality" (
+  "municipality_id" text PRIMARY KEY,
+  "municipality" varchar
+);
+
+CREATE TABLE IF NOT EXISTS "cdw"."current"."division" (
+  "division_id" text PRIMARY KEY,
+  "division" varchar
+);
+
+CREATE TABLE IF NOT EXISTS "cdw"."current"."service_type" (
+  "service_type_id" text PRIMARY KEY,
+  "service_type" varchar
+);
+
+CREATE TABLE IF NOT EXISTS "cdw"."current"."zoning_class" (
+  "zoning_class_id" text PRIMARY KEY,
+  "zoning_class" varchar
+);
+
+CREATE TABLE IF NOT EXISTS "cdw"."current"."use_type" (
+  "use_type_id" text PRIMARY KEY,
+  "use_type" text
+);
+
+CREATE TABLE IF NOT EXISTS "cdw"."current"."permit_type" (
+  "permit_type_id" text PRIMARY KEY,
+  "permit_type" varchar
+);
+
+CREATE TABLE IF NOT EXISTS "cdw"."current"."inspection_type" (
+  "inspection_type_id" text PRIMARY KEY,
+  "inspection_type" varchar
+);
+
+-- =============================================================================
+-- Shared entities (namespaced TEXT surrogate keys)
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS "cdw"."current"."address" (
+  "address_id" text PRIMARY KEY,
+  "raw_line" text,
+  "street_number" int,
+  "street_name_prefix" varchar,
+  "street_name" varchar,
+  "street_name_suffix" varchar,
+  "secondary_designator" varchar,
+  "city" varchar,
+  "state" varchar,
+  "zip" text
+);
+
+CREATE TABLE IF NOT EXISTS "cdw"."current"."legal_entity" (
+  "legal_entity_id" text PRIMARY KEY,
+  "name" varchar,
+  "address_id" text
+);
+
+-- =============================================================================
+-- Spine tables (CDW_ID component columns + generated STORED cdw_id PK)
+-- =============================================================================
+
 CREATE TABLE IF NOT EXISTS "cdw"."current"."parcel" (
-  "parcel_id" int PRIMARY KEY,
+  "country_code" text NOT NULL,
+  "region_code" text NOT NULL,
+  "parcel_seq" bigint NOT NULL,
+  "cdw_id" text GENERATED ALWAYS AS (
+    lpad("country_code", 4, '0') || '.' ||
+    lpad("region_code", 6, '0') || '.' ||
+    lpad("parcel_seq"::text, 8, '0') || '.' ||
+    '0000' || '.' ||
+    '00000'
+  ) STORED PRIMARY KEY,
   "county" varchar,
-  "owner_id" int,
+  "owner_id" text,
   "ward" int,
   "neighborhood" varchar,
-  "zip_code" int,
-  "census_block" int,
+  "zip_code" text,
+  "census_block" text,
   "frontage" int,
-  "zoning_class_id" int
+  "zoning_class_id" text
 );
 
 CREATE TABLE IF NOT EXISTS "cdw"."current"."building" (
-  "building_id" int PRIMARY KEY,
-  "parcel_id" int,
-  "owner_id" int,
-  "use_type_id" int,
+  "country_code" text NOT NULL,
+  "region_code" text NOT NULL,
+  "parcel_seq" bigint NOT NULL,
+  "building_seq" bigint NOT NULL,
+  "cdw_id" text GENERATED ALWAYS AS (
+    lpad("country_code", 4, '0') || '.' ||
+    lpad("region_code", 6, '0') || '.' ||
+    lpad("parcel_seq"::text, 8, '0') || '.' ||
+    lpad("building_seq"::text, 4, '0') || '.' ||
+    '00000'
+  ) STORED PRIMARY KEY,
+  "parcel_cdw_id" text NOT NULL,
+  "owner_id" text,
+  "use_type_id" text,
   "sq_footage" int,
   "year_built" int
 );
 
 CREATE TABLE IF NOT EXISTS "cdw"."current"."unit" (
-  "unit_id" int PRIMARY KEY,
-  "building_id" int,
-  "owner_id" int,
-  "use_type_id" int,
-  "address_id" int,
+  "country_code" text NOT NULL,
+  "region_code" text NOT NULL,
+  "parcel_seq" bigint NOT NULL,
+  "building_seq" bigint NOT NULL,
+  "unit_seq" bigint NOT NULL,
+  "cdw_id" text GENERATED ALWAYS AS (
+    lpad("country_code", 4, '0') || '.' ||
+    lpad("region_code", 6, '0') || '.' ||
+    lpad("parcel_seq"::text, 8, '0') || '.' ||
+    lpad("building_seq"::text, 4, '0') || '.' ||
+    lpad("unit_seq"::text, 5, '0')
+  ) STORED PRIMARY KEY,
+  "building_cdw_id" text NOT NULL,
+  "owner_id" text,
+  "use_type_id" text,
+  "address_id" text,
   "ground_floor" bool,
   "stories" float,
   "windows_ac" int,
@@ -36,69 +154,55 @@ CREATE TABLE IF NOT EXISTS "cdw"."current"."unit" (
   "garage" int
 );
 
-CREATE TABLE IF NOT EXISTS "cdw"."current"."legal_entity" (
-  "legal_entity_id" int PRIMARY KEY,
-  "name" varchar,
-  "address_id" int
-);
-
-CREATE TABLE IF NOT EXISTS "cdw"."current"."address" (
-  "address_id" int PRIMARY KEY,
-  "street_number" int,
-  "street_name_prefix" varchar,
-  "street_name" varchar,
-  "street_name_suffix" varchar,
-  "secondary_designator" varchar,
-  "city" varchar,
-  "state" varchar,
-  "zip" int
-);
+-- =============================================================================
+-- Operations / event tables (namespaced TEXT surrogate keys)
+-- =============================================================================
 
 CREATE TABLE IF NOT EXISTS "cdw"."current"."permit" (
-  "permit_id" int PRIMARY KEY,
-  "permit_type_id" int,
+  "permit_id" text PRIMARY KEY,
+  "permit_type_id" text,
   "application_date" date,
   "issue_date" date,
   "completion_date" date,
   "cancel_date" date,
   "description" varchar,
   "cost" float,
-  "applicant_id" int,
-  "contractor_id" int
+  "applicant_id" text,
+  "contractor_id" text
 );
 
 CREATE TABLE IF NOT EXISTS "cdw"."current"."service" (
-  "service_id" int PRIMARY KEY,
-  "parcel_id" int,
-  "building_id" int,
-  "unit_id" int,
-  "owner_id" int,
-  "division_id" int,
+  "service_id" text PRIMARY KEY,
+  "parcel_id" text,
+  "building_id" text,
+  "unit_id" text,
+  "owner_id" text,
+  "division_id" text,
   "service_date" date,
-  "service_type_id" int,
+  "service_type_id" text,
   "fee" float8
 );
 
 CREATE TABLE IF NOT EXISTS "cdw"."current"."condemnation" (
-  "condemnation_id" int PRIMARY KEY,
-  "inspection_id" int,
+  "condemnation_id" text PRIMARY KEY,
+  "inspection_id" text,
   "letter_date" date,
   "condemnation_type" varchar,
   "status" varchar
 );
 
 CREATE TABLE IF NOT EXISTS "cdw"."current"."inspection" (
-  "inspection_id" int PRIMARY KEY,
-  "building_id" int,
+  "inspection_id" text PRIMARY KEY,
+  "building_id" text,
   "inspection_date" date,
   "completion_date" date,
-  "inspection_type_id" int,
+  "inspection_type_id" text,
   "number_of_violations" int
 );
 
 CREATE TABLE IF NOT EXISTS "cdw"."current"."assessment" (
-  "assessment_id" int PRIMARY KEY,
-  "parcel_id" int,
+  "assessment_id" text PRIMARY KEY,
+  "parcel_id" text,
   "assessment_date" date,
   "assessment_amount" float,
   "land_value" float,
@@ -106,66 +210,79 @@ CREATE TABLE IF NOT EXISTS "cdw"."current"."assessment" (
 );
 
 CREATE TABLE IF NOT EXISTS "cdw"."current"."tax_delinquency" (
-  "tax_delinquency_id" int PRIMARY KEY,
-  "legal_entity_id" int,
+  "tax_delinquency_id" text PRIMARY KEY,
+  "legal_entity_id" text,
   "last_paid_year" int,
   "amount_delinquent" float
 );
 
-CREATE TABLE IF NOT EXISTS "cdw"."current"."municipality" (
-  "municipality_id" int PRIMARY KEY,
-  "municipality" varchar
-);
-
-CREATE TABLE IF NOT EXISTS "cdw"."current"."division" (
-  "division_id" int PRIMARY KEY,
-  "division" varchar
-);
-
-CREATE TABLE IF NOT EXISTS "cdw"."current"."service_type" (
-  "service_type_id" int PRIMARY KEY,
-  "service_type" varchar
-);
-
-CREATE TABLE IF NOT EXISTS "cdw"."current"."zoning_class" (
-  "zoning_class_id" int PRIMARY KEY,
-  "zoning_class" varchar
-);
+-- =============================================================================
+-- Native-reference preservation
+-- Preserves the city's native parcel reference (the assessor `handle`) and
+-- maps it to the CDW parcel cdw_id.
+-- NOTE: column previously misspelled `municpal_parcel_id`; corrected here to
+--       `municipal_parcel_id` (see report). Low-risk: no transform/DAG code
+--       references this column yet.
+-- =============================================================================
 
 CREATE TABLE IF NOT EXISTS "cdw"."current"."municipal_parcel_id_mapping" (
-  "parcel_id" int PRIMARY KEY,
-  "municpal_parcel_id" varchar,
-  "municipality_id" int
+  "parcel_id" text PRIMARY KEY,
+  "municipal_parcel_id" varchar,
+  "municipality_id" text
 );
 
-CREATE TABLE IF NOT EXISTS "cdw"."current"."use_type" (
-  "use_type_id" int PRIMARY KEY,
-  "use_type" int
+-- =============================================================================
+-- Capture tables
+-- =============================================================================
+
+-- Exclusion log: records filtered out of the warehouse (e.g. non-real-estate
+-- taxable accounts mixed in with parcels). Captures the source natural key, the
+-- reason for exclusion, and the raw source payload for later auditing/recovery.
+CREATE TABLE IF NOT EXISTS "cdw"."current"."exclusion_log" (
+  "exclusion_id" text PRIMARY KEY,
+  "source_table" varchar,
+  "source_natural_key" varchar,
+  "reason" varchar,
+  "raw_payload" jsonb,
+  "excluded_at" timestamptz DEFAULT now()
 );
 
-CREATE TABLE IF NOT EXISTS "cdw"."current"."permit_type" (
-  "permit_type_id" int PRIMARY KEY,
-  "permit_type" varchar
+-- Secondary owner: residual additional owners on multi-owner accounts that
+-- cannot be represented by the single parcel.owner_id. One row per extra owner.
+CREATE TABLE IF NOT EXISTS "cdw"."current"."secondary_owner" (
+  "secondary_owner_id" text PRIMARY KEY,
+  "parcel_id" text NOT NULL,
+  "owner_id" text NOT NULL,
+  "ownership_role" varchar,
+  "ownership_share" numeric
 );
 
-CREATE TABLE IF NOT EXISTS "cdw"."current"."inspection_type" (
-  "inspection_type_id" int PRIMARY KEY,
-  "inspection_type" varchar
-);
+-- =============================================================================
+-- Comments
+-- =============================================================================
 
-COMMENT ON COLUMN "cdw"."current"."parcel"."parcel_id" IS 'REDB identifier, not municapal identifier (handle)';
+COMMENT ON COLUMN "cdw"."current"."parcel"."cdw_id" IS 'CDW_ID standard key (CCCC.cccccc.pppppppp.0000.00000); building/unit segments zero-filled at parcel level';
+COMMENT ON COLUMN "cdw"."current"."building"."cdw_id" IS 'CDW_ID standard key (CCCC.cccccc.pppppppp.bbbb.00000); unit segment zero-filled at building level';
+COMMENT ON COLUMN "cdw"."current"."unit"."cdw_id" IS 'CDW_ID standard key (CCCC.cccccc.pppppppp.bbbb.uuuuu)';
+COMMENT ON COLUMN "cdw"."current"."municipal_parcel_id_mapping"."municipal_parcel_id" IS 'City native parcel reference (assessor handle); preserved for crosswalk back to source';
 
+-- =============================================================================
+-- Foreign keys
+-- =============================================================================
+
+-- Spine parentage (explicit parent FK columns)
+ALTER TABLE "cdw"."current"."building" ADD FOREIGN KEY ("parcel_cdw_id") REFERENCES "cdw"."current"."parcel" ("cdw_id");
+
+ALTER TABLE "cdw"."current"."unit" ADD FOREIGN KEY ("building_cdw_id") REFERENCES "cdw"."current"."building" ("cdw_id");
+
+-- Spine -> shared entities / lookups
 ALTER TABLE "cdw"."current"."parcel" ADD FOREIGN KEY ("owner_id") REFERENCES "cdw"."current"."legal_entity" ("legal_entity_id");
 
 ALTER TABLE "cdw"."current"."parcel" ADD FOREIGN KEY ("zoning_class_id") REFERENCES "cdw"."current"."zoning_class" ("zoning_class_id");
 
-ALTER TABLE "cdw"."current"."building" ADD FOREIGN KEY ("parcel_id") REFERENCES "cdw"."current"."parcel" ("parcel_id");
-
 ALTER TABLE "cdw"."current"."building" ADD FOREIGN KEY ("owner_id") REFERENCES "cdw"."current"."legal_entity" ("legal_entity_id");
 
 ALTER TABLE "cdw"."current"."building" ADD FOREIGN KEY ("use_type_id") REFERENCES "cdw"."current"."use_type" ("use_type_id");
-
-ALTER TABLE "cdw"."current"."unit" ADD FOREIGN KEY ("building_id") REFERENCES "cdw"."current"."building" ("building_id");
 
 ALTER TABLE "cdw"."current"."unit" ADD FOREIGN KEY ("owner_id") REFERENCES "cdw"."current"."legal_entity" ("legal_entity_id");
 
@@ -173,19 +290,21 @@ ALTER TABLE "cdw"."current"."unit" ADD FOREIGN KEY ("use_type_id") REFERENCES "c
 
 ALTER TABLE "cdw"."current"."unit" ADD FOREIGN KEY ("address_id") REFERENCES "cdw"."current"."address" ("address_id");
 
+-- Shared entities
 ALTER TABLE "cdw"."current"."legal_entity" ADD FOREIGN KEY ("address_id") REFERENCES "cdw"."current"."address" ("address_id");
 
+-- Operations / event tables
 ALTER TABLE "cdw"."current"."permit" ADD FOREIGN KEY ("permit_type_id") REFERENCES "cdw"."current"."permit_type" ("permit_type_id");
 
 ALTER TABLE "cdw"."current"."permit" ADD FOREIGN KEY ("applicant_id") REFERENCES "cdw"."current"."legal_entity" ("legal_entity_id");
 
 ALTER TABLE "cdw"."current"."permit" ADD FOREIGN KEY ("contractor_id") REFERENCES "cdw"."current"."legal_entity" ("legal_entity_id");
 
-ALTER TABLE "cdw"."current"."service" ADD FOREIGN KEY ("parcel_id") REFERENCES "cdw"."current"."parcel" ("parcel_id");
+ALTER TABLE "cdw"."current"."service" ADD FOREIGN KEY ("parcel_id") REFERENCES "cdw"."current"."parcel" ("cdw_id");
 
-ALTER TABLE "cdw"."current"."service" ADD FOREIGN KEY ("building_id") REFERENCES "cdw"."current"."building" ("building_id");
+ALTER TABLE "cdw"."current"."service" ADD FOREIGN KEY ("building_id") REFERENCES "cdw"."current"."building" ("cdw_id");
 
-ALTER TABLE "cdw"."current"."service" ADD FOREIGN KEY ("unit_id") REFERENCES "cdw"."current"."unit" ("unit_id");
+ALTER TABLE "cdw"."current"."service" ADD FOREIGN KEY ("unit_id") REFERENCES "cdw"."current"."unit" ("cdw_id");
 
 ALTER TABLE "cdw"."current"."service" ADD FOREIGN KEY ("owner_id") REFERENCES "cdw"."current"."legal_entity" ("legal_entity_id");
 
@@ -195,12 +314,20 @@ ALTER TABLE "cdw"."current"."service" ADD FOREIGN KEY ("service_type_id") REFERE
 
 ALTER TABLE "cdw"."current"."condemnation" ADD FOREIGN KEY ("inspection_id") REFERENCES "cdw"."current"."inspection" ("inspection_id");
 
-ALTER TABLE "cdw"."current"."inspection" ADD FOREIGN KEY ("building_id") REFERENCES "cdw"."current"."building" ("building_id");
+ALTER TABLE "cdw"."current"."inspection" ADD FOREIGN KEY ("building_id") REFERENCES "cdw"."current"."building" ("cdw_id");
 
 ALTER TABLE "cdw"."current"."inspection" ADD FOREIGN KEY ("inspection_type_id") REFERENCES "cdw"."current"."inspection_type" ("inspection_type_id");
 
-ALTER TABLE "cdw"."current"."assessment" ADD FOREIGN KEY ("parcel_id") REFERENCES "cdw"."current"."parcel" ("parcel_id");
+ALTER TABLE "cdw"."current"."assessment" ADD FOREIGN KEY ("parcel_id") REFERENCES "cdw"."current"."parcel" ("cdw_id");
 
 ALTER TABLE "cdw"."current"."tax_delinquency" ADD FOREIGN KEY ("legal_entity_id") REFERENCES "cdw"."current"."legal_entity" ("legal_entity_id");
 
-ALTER TABLE "cdw"."current"."municipal_parcel_id_mapping" ADD FOREIGN KEY ("parcel_id") REFERENCES "cdw"."current"."parcel" ("parcel_id");
+-- Native-reference preservation
+ALTER TABLE "cdw"."current"."municipal_parcel_id_mapping" ADD FOREIGN KEY ("parcel_id") REFERENCES "cdw"."current"."parcel" ("cdw_id");
+
+ALTER TABLE "cdw"."current"."municipal_parcel_id_mapping" ADD FOREIGN KEY ("municipality_id") REFERENCES "cdw"."current"."municipality" ("municipality_id");
+
+-- Capture tables
+ALTER TABLE "cdw"."current"."secondary_owner" ADD FOREIGN KEY ("parcel_id") REFERENCES "cdw"."current"."parcel" ("cdw_id");
+
+ALTER TABLE "cdw"."current"."secondary_owner" ADD FOREIGN KEY ("owner_id") REFERENCES "cdw"."current"."legal_entity" ("legal_entity_id");

--- a/include/sql/create_current.sql
+++ b/include/sql/create_current.sql
@@ -93,8 +93,8 @@ CREATE TABLE IF NOT EXISTS "cdw"."current"."parcel" (
   "region_code" text NOT NULL,
   "parcel_seq" bigint NOT NULL,
   "cdw_id" text GENERATED ALWAYS AS (
-    lpad("country_code", 4, '0') || '.' ||
-    lpad("region_code", 6, '0') || '.' ||
+    lpad("country_code", 3, '0') || '.' ||
+    lpad("region_code", 5, '0') || '.' ||
     lpad("parcel_seq"::text, 8, '0') || '.' ||
     '0000' || '.' ||
     '00000'
@@ -115,8 +115,8 @@ CREATE TABLE IF NOT EXISTS "cdw"."current"."building" (
   "parcel_seq" bigint NOT NULL,
   "building_seq" bigint NOT NULL,
   "cdw_id" text GENERATED ALWAYS AS (
-    lpad("country_code", 4, '0') || '.' ||
-    lpad("region_code", 6, '0') || '.' ||
+    lpad("country_code", 3, '0') || '.' ||
+    lpad("region_code", 5, '0') || '.' ||
     lpad("parcel_seq"::text, 8, '0') || '.' ||
     lpad("building_seq"::text, 4, '0') || '.' ||
     '00000'
@@ -135,8 +135,8 @@ CREATE TABLE IF NOT EXISTS "cdw"."current"."unit" (
   "building_seq" bigint NOT NULL,
   "unit_seq" bigint NOT NULL,
   "cdw_id" text GENERATED ALWAYS AS (
-    lpad("country_code", 4, '0') || '.' ||
-    lpad("region_code", 6, '0') || '.' ||
+    lpad("country_code", 3, '0') || '.' ||
+    lpad("region_code", 5, '0') || '.' ||
     lpad("parcel_seq"::text, 8, '0') || '.' ||
     lpad("building_seq"::text, 4, '0') || '.' ||
     lpad("unit_seq"::text, 5, '0')

--- a/include/staging_table_prep.py
+++ b/include/staging_table_prep.py
@@ -154,10 +154,12 @@ def create_table_in_postgres(filename, postgres_conn):
     sqlQueryCreate = ""
     sqlQueryCreate += "CREATE TABLE IF NOT EXISTS CDW.STAGING." + tablename + " (\n"
 
-    # Define columns for table
+    # Define columns for table. Staging is a raw landing area, so use TEXT to
+    # avoid silently truncating/dropping values that exceed a fixed width (e.g.
+    # decode-table descriptions longer than 64 chars).
     for column in columns:
         cleaned_column = clean_column_name(column)
-        sqlQueryCreate += cleaned_column + " VARCHAR(64),\n"
+        sqlQueryCreate += cleaned_column + " TEXT,\n"
 
     sqlQueryCreate = sqlQueryCreate[:-2]
     sqlQueryCreate += ");"
@@ -178,16 +180,24 @@ def create_staging_table(bucket, s3_conn_id, postgres_conn_id, key):
 def SQL_INSERT_STATEMENT_FROM_DATAFRAME(SOURCE, TARGET):
     # Generate the SQL insert statement from dataframe
     sql_texts = []
+    cleaned_columns = [clean_column_name(col) for col in SOURCE.columns]
     # COPY table (column1, column2, ...) FROM '/path/to/data.csv' WITH (FORMAT CSV)
     for index, row in SOURCE.iterrows():
-        cleaned_columns = [clean_column_name(col) for col in SOURCE.columns]
+        # Render every value as a single-quoted SQL string literal. The staging
+        # columns are all TEXT, and the values have already had their single
+        # quotes escaped to '' upstream. We build the literal explicitly rather
+        # than relying on str(tuple(...)), whose Python repr switches to double
+        # quotes for any value containing a single quote and produces invalid
+        # SQL (Postgres reads "..." as an identifier, not a string literal).
+        values = ", ".join("'" + str(value) + "'" for value in row.values)
         sql_texts.append(
             "INSERT INTO CDW.STAGING."
             + TARGET
             + " ("
             + ", ".join(cleaned_columns)
-            + ") VALUES "
-            + str(tuple(row.values))
+            + ") VALUES ("
+            + values
+            + ")"
         )
     return sql_texts
 
@@ -201,8 +211,12 @@ def populate_staging_table(bucket, s3_conn_id, postgres_conn, key):
     df = pd.read_csv(StringIO(obj))
     for column in df.columns:
         if df[column].dtype == object:
-            df[column] = df[column].replace("'", "''", inplace=True)
-    df.replace(np.nan, "None", inplace=True)
+            # Escape single quotes so the values are safe to embed in the
+            # INSERT ... VALUES (...) string built below. Using str.replace on
+            # the column (not Series.replace with inplace=True, which returns
+            # None and would wipe the entire column).
+            df[column] = df[column].str.replace("'", "''", regex=False)
+    df = df.replace(np.nan, "None")
     records = df.to_records(index=True)
 
     # Read table from S3 bucket


### PR DESCRIPTION
Foundation for the `staging` → `current` transformation layer: the design docs, the
`current`-schema DDL rewritten to the CDW_ID standard, and a staging ingestion bugfix.

## What's included
- **Design docs** (`8fc9f2f`) — CDW_ID standard (`documentation/schema/cdw_id.md`), the
  staging→current transformation design and phased plan
  (`documentation/pipeline_architecture/`), and the real-estate-only / condo clarifications in
  `documentation/schema/schema.md`.
- **Wave 0 — staging decode fix** (`fc84b9a`) — `include/staging_table_prep.py`.
- **Wave 1 — current DDL** (`a4f5db8`) + **width correction** (`e0ba669`) —
  `include/sql/create_current.sql`, `documentation/schema/schema.dbml`.

## Wave 0 — decode tables loading as literal `None`
Root cause: `df[column].replace("'", "''", inplace=True)` returns `None`, blanking every
text column; a subsequent `df.replace(np.nan, "None")` then stringified those to `"None"`.
Fixed (no `inplace`), plus a latent SQL single-quote/identifier-quoting bug, and widened staging
text columns `VARCHAR(64)` → `TEXT`. Reproduced and verified: `prclcode_cdlanduse` went from
852/852 `"None"` to 852/852 real descriptions. End-to-end re-run tracked in #45.

## Wave 1 — `current` schema to the CDW_ID standard
- Spine (`parcel`/`building`/`unit`): CDW_ID component columns + a generated `cdw_id` TEXT PK;
  explicit parent FK columns (`building.parcel_cdw_id`, `unit.building_cdw_id`).
- All non-spine tables: namespaced TEXT surrogate keys; all FKs converted to TEXT.
- Type widening (codes are TEXT): `zip_code`, `address.zip`, `census_block`, `use_type.use_type`.
- Added `address.raw_line`, plus `exclusion_log` and `secondary_owner` capture tables.
- Fixed the `municpal_parcel_id` → `municipal_parcel_id` column typo.
- Field widths corrected to the standard: country **3** / region **5** / parcel 8 / building 4 / unit 5.

## Verification
DDL applied to the running Postgres inside `BEGIN; DROP SCHEMA current CASCADE; \i …; ROLLBACK;`
— 21 tables created, FK chain valid, generated ids correct
(`parcel 840.29510.00012345.0000.00000`, `unit 840.29510.00012345.0007.00042`); shared state
left untouched.

## Follow-ups (tracked as issues)
- The full transformation backlog is issues #39–#81 (label `transform`), organized under the
  existing milestones (Primary Key Manager, Migrate Data to Data Spine, etc.).
- **Open decision:** `schema.dbml` normalization for model-only tables (#44).
- Post-merge staging verification: #45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
