### PR TITLE
Fix staging_table_prep OOM and column truncation

### DIFF
--- a/dags/staging_table_prep.py
+++ b/dags/staging_table_prep.py
@@ -61,10 +61,6 @@ with DAG(
         op_args=["civic-data-warehouse-lz", "s3_datalake", "cdw-dev"],
     ).expand(op_kwargs=prepare_list.output)
 
-    # TODO 'forestry_maintenance_properties' is failing to populate.
-    # column "category" of relation "forestry_maintenance_properties" does not exist
-    # column names for forestry_maintenance_properties are in "" for some reason? Not seeing that in other tables
-
     populate_staging_tables = PythonOperator.partial(
         task_id="populate_staging_tables",
         python_callable=populate_staging_table,

--- a/include/staging_table_prep.py
+++ b/include/staging_table_prep.py
@@ -1,14 +1,16 @@
 import logging
 import os
 import re
-from io import StringIO
 from logging import Logger
 
-import numpy as np
 import pandas as pd
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 from airflow.utils.log import logging_mixin
+
+# Identifiers cannot be passed as bound parameters, so any value interpolated
+# into a DDL/COPY statement must be validated against a strict allowlist first.
+SAFE_IDENTIFIER = re.compile(r"^[A-Za-z0-9_]+$")
 
 
 def download_from_s3(key: str, bucket_name: str, s3_conn_id: str):
@@ -153,14 +155,20 @@ def create_table_in_postgres(filename, postgres_conn):
     for col_index, column in enumerate(columns):
         logger.info(f"column index {col_index} is '{column}'")
 
-    # Build SQL code to drop table if exists and create table
-    sqlQueryCreate = ""
-    sqlQueryCreate += "CREATE TABLE IF NOT EXISTS CDW.STAGING." + tablename + " (\n"
+    if not SAFE_IDENTIFIER.match(tablename):
+        raise ValueError(f"Refusing to build DDL for unsafe table name {tablename!r}")
 
-    # Define columns for table
+    # Drop and recreate so the schema always matches the current CSV. The schema
+    # reset only truncates rows, so a CREATE TABLE IF NOT EXISTS would keep a
+    # stale schema from a previous run.
+    sqlQueryCreate = f"DROP TABLE IF EXISTS CDW.STAGING.{tablename} CASCADE;\n"
+    sqlQueryCreate += "CREATE TABLE CDW.STAGING." + tablename + " (\n"
+
+    # Staging is a raw landing zone: use TEXT so source values are never
+    # truncated or rejected for exceeding a fixed width.
     for column in columns:
         cleaned_column = clean_column_name(column)
-        sqlQueryCreate += cleaned_column + " VARCHAR(64),\n"
+        sqlQueryCreate += cleaned_column + " TEXT,\n"
 
     sqlQueryCreate = sqlQueryCreate[:-2]
     sqlQueryCreate += ");"
@@ -178,41 +186,57 @@ def create_staging_table(bucket, s3_conn_id, postgres_conn_id, key):
     create_table_in_postgres(filename="/tmp/" + key, postgres_conn=postgres_conn_id)
 
 
-def SQL_INSERT_STATEMENT_FROM_DATAFRAME(SOURCE, TARGET):
-    # Generate the SQL insert statement from dataframe
-    sql_texts = []
-    # COPY table (column1, column2, ...) FROM '/path/to/data.csv' WITH (FORMAT CSV)
-    for index, row in SOURCE.iterrows():
-        cleaned_columns = [clean_column_name(col) for col in SOURCE.columns]
-        sql_texts.append(
-            "INSERT INTO CDW.STAGING."
-            + TARGET
-            + " ("
-            + ", ".join(cleaned_columns)
-            + ") VALUES "
-            + str(tuple(row.values))
+def staging_table_name(key: str) -> str:
+    """Derive the staging table name from an S3 key.
+
+    Mirrors the transformation in create_table_in_postgres so the populate step
+    targets the same table the create step built.
+    """
+    tablename = key.replace(".csv", "").replace("-", "_")
+    if not SAFE_IDENTIFIER.match(tablename):
+        raise ValueError(
+            f"Refusing to build COPY for unsafe table name {tablename!r} (from key {key!r})"
         )
-    return sql_texts
+    return tablename
 
 
 def populate_staging_table(bucket, s3_conn_id, postgres_conn, key):
     logger = logging_mixin.LoggingMixin().logger()
-    # Import table from S3 bucket to a pandas dataframe and convert to an array
     logger.info("Attempting to populate " + key)
+
+    tablename = staging_table_name(key)
+
+    # Stream the object to local disk instead of loading it into memory; source
+    # files can be hundreds of MB and the previous row-by-row INSERT approach
+    # built the entire dataset as SQL strings in RAM, which triggered OOM kills.
     hook = S3Hook(aws_conn_id=s3_conn_id)
-    obj = hook.read_key(bucket_name=bucket, key=key)
-    df = pd.read_csv(StringIO(obj))
-    for column in df.columns:
-        if df[column].dtype == object:
-            df[column] = df[column].replace("'", "''", inplace=True)
-    df.replace(np.nan, "None", inplace=True)
+    local_path = hook.download_file(key=key, bucket_name=bucket, local_path="/tmp/")
 
-    # Read table from S3 bucket
-    filename = "/tmp/" + key
-    tablename = filename.replace("/tmp/", "").replace(".csv", "").replace("-", "_")
+    try:
+        # Derive column names exactly as create_table_in_postgres does, via
+        # pandas, so they match the table even for quirks like blank headers
+        # (pandas labels them "Unnamed: N"). Mapping by name rather than position
+        # means an upstream column reorder still loads correctly, and an unknown
+        # column fails loudly instead of silently shifting every value over.
+        header = pd.read_csv(local_path, nrows=0, dtype=str).columns
+        columns = [clean_column_name(col) for col in header]
+        for column in columns:
+            if not SAFE_IDENTIFIER.match(column):
+                raise ValueError(f"Unsafe column name {column!r} in {key}")
+        column_list = ", ".join(columns)
 
-    # Build SQL code to insert data into table
-    sqlQueryInsert = SQL_INSERT_STATEMENT_FROM_DATAFRAME(df, tablename)
-    logger.debug(sqlQueryInsert)
-    # run sqlQueryCreate in Postgres
-    execute_query(sqlQueryInsert, postgres_conn, logger)
+        # Bulk-load via COPY: libpq streams the file so memory stays flat
+        # regardless of size, and Postgres handles CSV quoting/escaping. HEADER
+        # true skips the first line; the explicit column list controls mapping.
+        # The unquoted table name folds to lower case to match CREATE TABLE.
+        copy_sql = (
+            f"COPY cdw.staging.{tablename} ({column_list}) "
+            "FROM STDIN WITH (FORMAT CSV, HEADER true)"
+        )
+        pg_hook = PostgresHook(postgres_conn_id=postgres_conn)
+        pg_hook.copy_expert(sql=copy_sql, filename=local_path)
+    finally:
+        if os.path.exists(local_path):
+            os.remove(local_path)
+
+    logger.info("Populated cdw.staging." + tablename)


### PR DESCRIPTION
 ## What
 
 `populate_staging_tables` was failing on several mapped files. This reworks
  the staging load to fix three distinct failures surfaced from real runs.

  ## Changes

  - **OOM on large files.** `populate_staging_table` no longer builds one
    `INSERT` string per row in memory (which OOM-killed on the ~546 MB
    `prcl_PrclREAR.csv`). It now bulk-loads via streaming `COPY`, so memory
    stays flat regardless of file size.
  - **`VARCHAR(64)` truncation.** Staging tables are now `DROP`/recreated with
    `TEXT` columns instead of `VARCHAR(64)`, so source values are never
    rejected for length. The schema reset only truncates rows, so the old
    `CREATE TABLE IF NOT EXISTS` kept stale `VARCHAR(64)` schemas across runs.
  - **Quoted / blank headers.** `COPY` maps CSV fields to columns **by name**,
    with names derived via pandas exactly as the create step does. This fixes
    the `forestry_maintenance_properties` quoted-header failure and the
    blank-header column in `cndcodes.csv` (`Unnamed: 0`). A future upstream
    column reorder now loads correctly; an unknown column fails loudly instead
    of silently shifting data.
  - Table and column names are validated against an allowlist before being
    interpolated into SQL.

  ## Testing

  - End-to-end `create` + `populate` verified against localstack S3 + Postgres
    for `prcl_PrclREAR.csv` (was OOM), `PrclCode_CdAttrTypeNum.csv` (was
    truncated), `cndcodes.csv` (blank header), and
    `forestry_maintenance_properties.csv` (quoted header) — all load with
    correct column alignment.
  - Proactively scanned all 124 bucket headers: no duplicate or empty cleaned
    column names remain.
  - `ruff check`, `ruff format --check`, and `pytest` all pass.

 Co-authored by [Claude Code](https://claude.com/claude-code) Opus 4.8