### PR TITLE
Create crosswalk parcel_xref registry for CDW parcel IDsAdd crosswalk parcel xref registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ CDW PostgreSQL (Data Warehouse)
 A dedicated Postgres 15 instance that serves as the **data warehouse** itself. This is separate from Airflow's internal metadata database. It contains three schemas:
 
 - **`staging`** — raw data loaded directly from S3 CSVs
+- **`crosswalk`** — persistent CDW_ID registries such as parcel handle → parcel sequence mappings
 - **`current`** — normalized tables (parcel, building, unit, address, legal_entity, etc.)
 - **`history`** — historical snapshots of the current schema
 
@@ -74,9 +75,9 @@ All DAGs are manually triggered (`schedule=None`) unless noted otherwise. They s
 
 **File:** `dags/create_cdw_databases.py`
 
-Creates the three CDW schemas (`staging`, `current`, `history`) and a utility function for truncating tables. Run this once before any other DAG.
+Creates the CDW schemas (`staging`, `crosswalk`, `current`, `history`) and a utility function for truncating tables. Run this once before any other DAG. The `crosswalk` schema is persistent ID registry state and should not be truncated during normal rebuilds.
 
-**Task order:** `create_staging` > `create_data_prep` > `create_history` > `create_truncate_tables_function`
+**Task order:** `create_staging` > `create_crosswalk` > `create_data_prep` > `create_history` > `create_truncate_tables_function`
 
 ### 2. `govt_file_download` — Data Ingestion
 
@@ -109,7 +110,7 @@ Truncates the `staging` schema, lists all files in the S3 landing zone, then dyn
 
 | DAG | File | Purpose |
 |-----|------|---------|
-| `sql_test` | `dags/sql_test.py` | Connectivity check — verifies the `staging`, `current`, and `history` schemas exist in the CDW database. |
+| `sql_test` | `dags/sql_test.py` | Connectivity check — verifies the `staging`, `crosswalk`, `current`, and `history` schemas exist in the CDW database. |
 | `example_secrets_dag` | `dags/secret_manager_test.py` | Tests secrets backend integration by retrieving an Airflow Variable and the `cdw-dev` connection. |
 | `survey_dag_parsing_times` | `dags/dag_parsing_survey.py` | Profiles DAG parse times. **Only DAG with a schedule** (daily). |
 

--- a/dags/create_cdw_databases.py
+++ b/dags/create_cdw_databases.py
@@ -24,6 +24,13 @@ with DAG(
         sql="create_staging.sql",
     )
 
+    # Create schema "crosswalk" in cdw database
+    create_crosswalk = SQLExecuteQueryOperator(
+        task_id="create_crosswalk",
+        conn_id="cdw-dev",
+        sql="create_crosswalk.sql",
+    )
+
     # Create schema "current" in cdw database
     create_current = SQLExecuteQueryOperator(
         task_id="create_data_prep",
@@ -43,4 +50,10 @@ with DAG(
         conn_id="cdw-dev",
         sql="create_truncate_tables_function.sql",
     )
-create_staging >> create_current >> create_history >> create_truncate_tables_function
+(
+    create_staging
+    >> create_crosswalk
+    >> create_current
+    >> create_history
+    >> create_truncate_tables_function
+)

--- a/dags/sql_test.py
+++ b/dags/sql_test.py
@@ -15,5 +15,5 @@ with DAG(
     truncate_staging = SQLExecuteQueryOperator(
         task_id="sql_test",
         conn_id="cdw-dev",
-        sql="SELECT schema_name FROM information_schema.schemata WHERE schema_name IN ('staging', 'current', 'history')",
+        sql="SELECT schema_name FROM information_schema.schemata WHERE schema_name IN ('staging', 'crosswalk', 'current', 'history')",
     )

--- a/documentation/pipeline_architecture/staging_to_current.md
+++ b/documentation/pipeline_architecture/staging_to_current.md
@@ -83,6 +83,8 @@ Identity & crosswalk
 - Parcel `cdw_id` = `840.29510.<parcel_seq>.0000.00000`, where `parcel_seq` is minted from `handle`
   via `crosswalk.parcel_xref` (the authoritative per-region registry). `handle` is preserved in
   `current.municipal_parcel_id_mapping`.
+- `crosswalk.parcel_xref` is persistent pipeline state. It survives current-schema rebuilds so an
+  existing native `handle` keeps the same `parcel_seq` on every run.
 - Building = `…<bldgnum:4>.00000`; unit = `…<bldgnum:4>.<unitseq:5>`. Condo buildings synthesize
   `…0001.00000`; condo units order deterministically by assessor parcel number.
 - Non-spine surrogates are namespaced TEXT (`840.29510.<entity>.<seq>`). See

--- a/documentation/schema/cdw_id.md
+++ b/documentation/schema/cdw_id.md
@@ -79,6 +79,11 @@ The crosswalk (`crosswalk.parcel_xref`: region, native reference `UNIQUE`, parce
 regenerated. Sequences are collision-free within a region; the one disallowed situation is two
 independent crosswalks minting the same region.
 
+Operationally, `include/sql/create_crosswalk.sql` creates this registry. New rows in
+`crosswalk.parcel_xref` may omit `parcel_seq`; a trigger allocates the next value from the
+region-specific Postgres sequence. Pipeline rebuilds should read and append to this table, not
+truncate it.
+
 Storage
 =======
 A full CDW_ID is far wider than a 64-bit integer, so it is stored as **TEXT**, not a number.

--- a/include/sql/create_crosswalk.sql
+++ b/include/sql/create_crosswalk.sql
@@ -1,0 +1,112 @@
+-- =============================================================================
+-- CDW "crosswalk" schema DDL
+-- -----------------------------------------------------------------------------
+-- Persistent ID registries used while transforming source records into the CDW
+-- spine. Crosswalk tables are authoritative state: they are not staging output
+-- and must not be truncated or regenerated during normal pipeline rebuilds.
+-- =============================================================================
+
+CREATE SCHEMA IF NOT EXISTS crosswalk;
+
+CREATE TABLE IF NOT EXISTS crosswalk.parcel_xref (
+  region_code text NOT NULL,
+  native_ref text NOT NULL,
+  parcel_seq bigint NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT parcel_xref_pkey PRIMARY KEY (region_code, native_ref),
+  CONSTRAINT parcel_xref_region_seq_key UNIQUE (region_code, parcel_seq),
+  CONSTRAINT parcel_xref_region_code_not_blank CHECK (btrim(region_code) <> ''),
+  CONSTRAINT parcel_xref_native_ref_not_blank CHECK (btrim(native_ref) <> ''),
+  CONSTRAINT parcel_xref_parcel_seq_positive CHECK (parcel_seq > 0)
+);
+
+COMMENT ON SCHEMA crosswalk IS
+  'Persistent CDW_ID crosswalks. Authoritative ID registry; do not truncate or regenerate.';
+
+COMMENT ON TABLE crosswalk.parcel_xref IS
+  'Authoritative mapping from a region-native parcel reference to the stable CDW parcel sequence.';
+
+COMMENT ON COLUMN crosswalk.parcel_xref.region_code IS
+  'Parcel-issuing jurisdiction namespace, e.g. St. Louis City FIPS 29510.';
+
+COMMENT ON COLUMN crosswalk.parcel_xref.native_ref IS
+  'Native parcel reference from the source system, e.g. the St. Louis assessor handle.';
+
+COMMENT ON COLUMN crosswalk.parcel_xref.parcel_seq IS
+  'CDW-minted parcel localId. Unique within region_code and never reassigned.';
+
+CREATE OR REPLACE FUNCTION crosswalk.parcel_seq_sequence_name(region_code text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT 'parcel_seq_' || regexp_replace(btrim(region_code), '[^A-Za-z0-9_]+', '_', 'g');
+$$;
+
+COMMENT ON FUNCTION crosswalk.parcel_seq_sequence_name(text) IS
+  'Returns the per-region sequence name used to allocate parcel_xref.parcel_seq values.';
+
+CREATE OR REPLACE FUNCTION crosswalk.next_parcel_seq(region_code text)
+RETURNS bigint
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  normalized_region text := btrim(region_code);
+  sequence_name text;
+BEGIN
+  IF normalized_region IS NULL OR normalized_region = '' THEN
+    RAISE EXCEPTION 'region_code is required to allocate a parcel sequence';
+  END IF;
+
+  sequence_name := crosswalk.parcel_seq_sequence_name(normalized_region);
+
+  IF to_regclass(format('%I.%I', 'crosswalk', sequence_name)) IS NULL THEN
+    EXECUTE format(
+      'CREATE SEQUENCE IF NOT EXISTS %I.%I AS bigint START WITH 1 INCREMENT BY 1 NO MINVALUE NO MAXVALUE CACHE 1',
+      'crosswalk',
+      sequence_name
+    );
+  END IF;
+
+  RETURN nextval(format('%I.%I', 'crosswalk', sequence_name)::regclass);
+END;
+$$;
+
+COMMENT ON FUNCTION crosswalk.next_parcel_seq(text) IS
+  'Allocates the next parcel sequence from the sequence dedicated to the given region_code.';
+
+CREATE OR REPLACE FUNCTION crosswalk.set_parcel_xref_defaults()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.region_code := btrim(NEW.region_code);
+  NEW.updated_at := now();
+
+  IF NEW.parcel_seq IS NULL THEN
+    NEW.parcel_seq := crosswalk.next_parcel_seq(NEW.region_code);
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION crosswalk.set_parcel_xref_defaults() IS
+  'Assigns parcel_seq from the region-specific sequence when a parcel_xref row omits it.';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgname = 'parcel_xref_set_defaults'
+      AND tgrelid = 'crosswalk.parcel_xref'::regclass
+  ) THEN
+    CREATE TRIGGER parcel_xref_set_defaults
+    BEFORE INSERT OR UPDATE ON crosswalk.parcel_xref
+    FOR EACH ROW
+    EXECUTE FUNCTION crosswalk.set_parcel_xref_defaults();
+  END IF;
+END;
+$$;


### PR DESCRIPTION
# Create crosswalk parcel_xref registry for CDW parcel IDs

Refs #39

This adds the persistent `crosswalk` schema and `parcel_xref` table used to mint stable CDW parcel sequence IDs from native parcel references.

## What changed

- Adds `include/sql/create_crosswalk.sql`
  - Creates `crosswalk` schema.
  - Creates `crosswalk.parcel_xref`.
  - Stores `(region_code, native_ref, parcel_seq)`.
  - Enforces one stable parcel sequence per `(region_code, native_ref)`.
  - Enforces unique parcel sequences within each region.
  - Adds per-region Postgres sequences, created lazily when a region first needs one.
  - Adds a trigger that assigns `parcel_seq` automatically when omitted.

- Wires `create_crosswalk.sql` into `cdw_creation`
  - New task order:
    `create_staging` > `create_crosswalk` > `create_data_prep` > `create_history` > `create_truncate_tables_function`

- Updates docs
  - README now lists `crosswalk` as a CDW schema.
  - `cdw_id.md` explains that `crosswalk.parcel_xref` is persistent authoritative state.
  - `staging_to_current.md` clarifies that the crosswalk survives `current` rebuilds.

## Why

The CDW parcel ID uses a CDW-minted parcel sequence, not the city's native parcel handle directly.

For example:

```text
region_code = 29510
native_ref = <St. Louis assessor handle>
parcel_seq = 12345
cdw_id = 840.29510.00012345.0000.00000
```

The crosswalk is the registry that makes that mapping stable across reruns.

## Verification

Applied `include/sql/create_crosswalk.sql` twice inside a rolled-back Postgres transaction against local `cdw_postgres`.

Inserted sample rows and confirmed per-region sequence behavior:

```text
29510 / HANDLE_A -> 1
29510 / HANDLE_B -> 2
47157 / HANDLE_A -> 1
```

Confirmed rollback left the shared database unchanged.

Also ran:

```bash
astro dev parse
ruff format --check dags include tests
ruff check dags include tests
python -m compileall -q dags include tests
```

## Follow-ups

This PR only creates the registry structure. Later transform issues still need to populate it from staging parcel handles and use it while loading `current.parcel`.

## Persistence note

`crosswalk.parcel_xref` is persistent database state, not derived staging/current output. Normal rebuilds should read from and append to it, not truncate or regenerate it.

This makes parcel sequence assignments stable inside a shared or persisted database. A brand-new local database will start with an empty crosswalk unless production/shared crosswalk state is restored or seeded.
